### PR TITLE
✨ update: APIエラーハンドリングを充実させる #24

### DIFF
--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -1,6 +1,36 @@
+// API エラーの種類を定義
+export enum ApiErrorType {
+  TIMEOUT = 'TIMEOUT', // リクエストタイムアウト
+  RATE_LIMITED = 'RATE_LIMITED', // API レート制限（429）
+  SERVER_ERROR = 'SERVER_ERROR', // サーバーエラー（5xx）
+  CLIENT_ERROR = 'CLIENT_ERROR', // クライアントエラー（4xx）
+  NETWORK_ERROR = 'NETWORK_ERROR', // ネットワークエラー
+}
+
+// Apiエラークラス
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    public type: ApiErrorType,
+    public statusCode?: number,
+    public retryable: boolean = false,
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
 interface RequestOptions extends RequestInit {
   params?: Record<string, string>;
+  timeout?: number; // ミリ秒単位のタイムアウト（デフォルト: 10000）
+  retries?: number; // リトライ回数（デフォルト: 3）
 }
+
+// リトライ可能なHTTPステータスコード
+const RETRYABLE_STATUS_CODES = [408, 429, 500, 502, 503, 504];
+
+// リトライ不可のHTTPステータスコード（クライアントエラー）
+const NON_RETRYABLE_STATUS_CODES = [400, 401, 403, 404];
 
 class ApiClient {
   private baseUrl: string;
@@ -8,6 +38,10 @@ class ApiClient {
   // APIキーをクエリパラメータとして渡すか、ヘッダーで渡すかを指定
   private keyLocation: 'query' | 'header';
   private keyName: string;
+
+  // デフォルト設定
+  private readonly DEFAULT_TIMEOUT_MS = 10000; // 10秒
+  private readonly DEFAULT_RETRIES = 3;
 
   constructor(
     baseUrl: string,
@@ -21,7 +55,79 @@ class ApiClient {
     this.keyName = keyName;
   }
 
-  private async request<T>(endpoint: string, options: RequestOptions = {}): Promise<T> {
+  /**
+   * 指数バックオフでのリトライ間隔を計算
+   * @param attempt リトライ回数（0から開始）
+   * @returns 待機時間（ミリ秒） Max 5000ms
+   * 7回目以降は5000ms固定
+   */
+  private getBackoffDelay(attempt: number): number {
+    // 100ms, 200ms, 400ms, ...
+    return Math.min(100 * Math.pow(2, attempt), 5000);
+  }
+
+  /**
+   * リトライ可能かどうかを判定
+   * @param statusCode HTTPステータスコード
+   * @param error エラーオブジェクト
+   * @returns リトライ可能な場合は true
+   */
+  private isRetryable(statusCode?: number, error?: Error): boolean {
+    if (!statusCode) {
+      // ネットワークエラーの場合、リトライ可能
+      return error instanceof TypeError && error.message.includes('fetch');
+    }
+    return RETRYABLE_STATUS_CODES.includes(statusCode);
+  }
+
+  /**
+   * エラーレスポンスを詳細に解析
+   */
+  private async parseErrorResponse(response: Response): Promise<string> {
+    try {
+      const contentType = response.headers.get('content-type');
+      if (contentType?.includes('application/json')) {
+        const data = await response.json();
+        return data.message || data.error || `HTTP ${response.status}`;
+      }
+      return await response.text();
+    } catch {
+      return `HTTP ${response.status} ${response.statusText}`;
+    }
+  }
+
+  /**
+   * APIエラーを分類して ApiError インスタンスを作成
+   */
+  private createApiError(statusCode: number, message: string): ApiError {
+    let type: ApiErrorType;
+    let retryable = false;
+
+    if (statusCode === 429) {
+      type = ApiErrorType.RATE_LIMITED;
+      retryable = true;
+    } else if (RETRYABLE_STATUS_CODES.includes(statusCode)) {
+      type = ApiErrorType.SERVER_ERROR;
+      retryable = true;
+    } else if (NON_RETRYABLE_STATUS_CODES.includes(statusCode)) {
+      type = ApiErrorType.CLIENT_ERROR;
+      retryable = false;
+    } else {
+      type = ApiErrorType.SERVER_ERROR;
+      retryable = statusCode >= 500;
+    }
+
+    return new ApiError(message, type, statusCode, retryable);
+  }
+
+  private async request<T>(
+    endpoint: string,
+    options: RequestOptions = {},
+    attempt: number = 0,
+  ): Promise<T> {
+    const timeout = options.timeout ?? this.DEFAULT_TIMEOUT_MS;
+    const maxRetries = options.retries ?? this.DEFAULT_RETRIES;
+
     const { params, headers, ...rest } = options;
     const url = new URL(`${this.baseUrl}${endpoint}`);
 
@@ -45,18 +151,94 @@ class ApiClient {
       requestHeaders.set(this.keyName, this.apiKey);
     }
 
-    const response = await fetch(url.toString(), {
-      headers: requestHeaders,
-      ...rest,
-    });
+    try {
+      // AbortController でタイムアウトを実装
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), timeout);
 
-    if (!response.ok) {
-      // TODO: より詳細なエラーハンドリング
-      const errorData = await response.json();
-      throw new Error(errorData.message || 'API request failed');
+      const response = await fetch(url.toString(), {
+        headers: requestHeaders,
+        signal: controller.signal,
+        ...rest,
+      });
+
+      clearTimeout(timeoutId);
+
+      if (!response.ok) {
+        const errorMessage = await this.parseErrorResponse(response);
+        const error = this.createApiError(response.status, errorMessage);
+
+        // リトライ可能かつ、リトライ回数が残っている場合
+        if (error.retryable && attempt < maxRetries) {
+          const delay = this.getBackoffDelay(attempt);
+          console.warn(
+            `[API] Retry attempt ${attempt + 1}/${maxRetries} for ${endpoint} after ${delay}ms`,
+          );
+          await new Promise((resolve) => setTimeout(resolve, delay));
+          return this.request<T>(endpoint, options, attempt + 1);
+        }
+
+        throw error;
+      }
+
+      return response.json() as Promise<T>;
+    } catch (error) {
+      // タイムアウトの場合
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        const timeoutError = new ApiError(
+          `Request timeout after ${timeout}ms`,
+          ApiErrorType.TIMEOUT,
+          undefined,
+          true, // リトライ可能
+        );
+
+        // タイムアウトもリトライ対象
+        if (attempt < maxRetries) {
+          const delay = this.getBackoffDelay(attempt);
+          console.warn(
+            `[API] Retry attempt ${attempt + 1}/${maxRetries} after timeout (${delay}ms)`,
+          );
+          await new Promise((resolve) => setTimeout(resolve, delay));
+          return this.request<T>(endpoint, options, attempt + 1);
+        }
+
+        throw timeoutError;
+      }
+
+      // ネットワークエラー（fetch 失敗）
+      if (error instanceof TypeError) {
+        const networkError = new ApiError(
+          `Network error: ${error.message}`,
+          ApiErrorType.NETWORK_ERROR,
+          undefined,
+          this.isRetryable(undefined, error),
+        );
+
+        if (networkError.retryable && attempt < maxRetries) {
+          const delay = this.getBackoffDelay(attempt);
+          console.warn(
+            `[API] Retry attempt ${attempt + 1}/${maxRetries} after network error (${delay}ms)`,
+          );
+          await new Promise((resolve) => setTimeout(resolve, delay));
+          return this.request<T>(endpoint, options, attempt + 1);
+        }
+
+        throw networkError;
+      }
+
+      // ApiError の場合はそのままスロー
+      if (error instanceof ApiError) {
+        throw error;
+      }
+
+      // 予期しないエラー
+      throw new ApiError(
+        `Unexpected error: ${error instanceof Error ? error.message : String(error)}`,
+        ApiErrorType.NETWORK_ERROR,
+        undefined,
+        false,
+      );
     }
-
-    return response.json() as Promise<T>;
   }
 
   public get<T>(endpoint: string, options?: RequestOptions): Promise<T> {
@@ -74,8 +256,6 @@ class ApiClient {
       body: JSON.stringify(data),
     });
   }
-
-  // 必要に応じてput, deleteなども追加
 }
 
 // 各API用のクライアントインスタンスをエクスポート

--- a/src/lib/apiErrorUtils.ts
+++ b/src/lib/apiErrorUtils.ts
@@ -1,0 +1,78 @@
+import { ApiError, ApiErrorType } from './apiClient';
+
+// ApiError インスタンスかどうかを判定
+export function isApiError(error: unknown): error is ApiError {
+  return error instanceof ApiError;
+}
+
+// エラー型から日本語のメッセージを生成
+export function getErrorMessage(error: ApiError): string {
+  switch (error.type) {
+    case ApiErrorType.TIMEOUT:
+      return '通信がタイムアウトしました。インターネット接続を確認して、もう一度お試しください。';
+
+    case ApiErrorType.RATE_LIMITED:
+      return 'API の使用制限に達しました。数分後にお試しください。';
+
+    case ApiErrorType.SERVER_ERROR:
+      return 'サーバーで問題が発生しました。サポートに連絡してください。';
+
+    case ApiErrorType.CLIENT_ERROR:
+      return 'リクエストが無効です。入力内容を確認してください。';
+
+    case ApiErrorType.NETWORK_ERROR:
+      return 'ネットワーク接続を確認してください。';
+
+    default:
+      return 'エラーが発生しました。もう一度お試しください。';
+  }
+}
+
+// リトライ可能かどうかを判定
+export function isRetryable(error: ApiError): boolean {
+  return error.retryable;
+}
+
+/**
+ * エラーをログに記録（構造化ログ）
+ */
+export function logApiError(error: ApiError, context?: Record<string, unknown>): void {
+  const logData = {
+    type: 'API_ERROR',
+    errorType: error.type,
+    statusCode: error.statusCode,
+    message: error.message,
+    retryable: error.retryable,
+    timestamp: new Date().toISOString(),
+    ...context,
+  };
+  console.log('[API Error]', logData);
+}
+
+/**
+ * リトライ可能なエラーの場合、待機して再試行する
+ * （ApiClient の内部リトライが失敗した場合用）
+ */
+export async function retryWithBackoff<T>(
+  fn: () => Promise<T>,
+  maxRetries: number = 3,
+  initialDelay: number = 100,
+): Promise<T> {
+  let lastError: Error | undefined;
+
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+
+      if (attempt < maxRetries - 1) {
+        const delay = initialDelay * Math.pow(2, attempt);
+        console.warn(`[Retry] Attempt ${attempt + 1} failed, retrying in ${delay}ms...`);
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
+    }
+  }
+
+  throw lastError;
+}


### PR DESCRIPTION
1. src/lib/apiClient.ts
    - ApiError クラス - 型情報、ステータスコード、リトライ可否を持つカスタムエラー
    - ApiErrorType 列挙型 - TIMEOUT, RATE_LIMITED, SERVER_ERROR, CLIENT_ERROR, NETWORK_ERROR
    - タイムアウト機構 - AbortController でデフォルト 10秒
    - リトライロジック - 指数バックオフで最大 3回リトライ
    - エラー分類 - ステータスコード別に詳細に分類
2. src/lib/apiErrorUtils.ts
    - ユーティリティ関数 6つ（型ガード、メッセージ生成、ログなど）