### PR TITLE
ソーシャルログイン追加（Google） #33

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# Supabase
+NEXT_PUBLIC_SUPABASE_URL=your_supabase_url
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
+DATABASE_URL=your_database_url
+
+# External APIs
+OPENWEATHERMAP_API_KEY=your_weather_api_key
+NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=your_google_maps_api_key
+
+# Auth
+AUTH_SECRET=your_auth_secret
+AUTH_URL=http://localhost:3000
+
+# Google
+AUTH_GOOGLE_ID="google_client_id"
+AUTH_GOOGLE_SECRET="google_client_secret"

--- a/docs/authentication-diagrams.md
+++ b/docs/authentication-diagrams.md
@@ -1,0 +1,495 @@
+# 🔐 認証システム フロー図・シーケンス図
+
+このドキュメントでは、Fishing Conditions Appの認証システムのフロー図とシーケンス図を提供します。
+
+---
+
+## 📊 全体認証フロー図
+
+```mermaid
+flowchart TD
+    Start([ユーザー訪問]) --> CheckAuth{認証済み?}
+
+    CheckAuth -->|Yes| Dashboard[/dashboard へ/]
+    CheckAuth -->|No| LoginChoice{認証方法選択}
+
+    LoginChoice -->|Credentials| CredLogin[メール/パスワード<br/>ログイン]
+    LoginChoice -->|Google OAuth| GoogleLogin[Googleログイン]
+    LoginChoice -->|新規登録| RegisterChoice{登録方法選択}
+
+    RegisterChoice -->|Credentials| CredRegister[メール/パスワード<br/>新規登録]
+    RegisterChoice -->|Google OAuth| GoogleRegister[Googleで登録]
+
+    CredLogin --> CredAuth[Credentials認証処理]
+    GoogleLogin --> GoogleAuth[Google OAuth処理]
+
+    CredRegister --> CreateCredUser[ユーザー作成<br/>auth_users + public_users]
+    GoogleRegister --> GoogleAuth
+
+    GoogleAuth --> CheckExisting{既存ユーザー?}
+    CheckExisting -->|Yes| LinkAccount[アカウント連携<br/>identities追加]
+    CheckExisting -->|No| CreateOAuthUser[ユーザー作成<br/>auth_users + public_users<br/>+ identities]
+
+    CredAuth --> AuthSuccess{認証成功?}
+    CreateCredUser --> LoginRedirect[/loginへリダイレクト/]
+    LinkAccount --> AuthSuccess
+    CreateOAuthUser --> AuthSuccess
+    LoginRedirect --> CredLogin
+
+    AuthSuccess -->|Success| CreateSession[セッション作成]
+    AuthSuccess -->|Failure| ShowError[エラー表示]
+
+    CreateSession --> Dashboard
+    ShowError --> LoginChoice
+
+    Dashboard --> UserAction{ユーザー操作}
+    UserAction -->|ログアウト| Logout[セッション削除]
+    UserAction -->|継続利用| Dashboard
+
+    Logout --> Start
+
+    style Dashboard fill:#90EE90
+    style ShowError fill:#FFB6C1
+    style CreateSession fill:#87CEEB
+    style LinkAccount fill:#FFD700
+```
+
+---
+
+## 🔑 Credentials認証シーケンス図
+
+### 新規登録フロー
+
+```mermaid
+sequenceDiagram
+    actor User as ユーザー
+    participant UI as /register
+    participant Action as signup()
+    participant Validation as Zod Validator
+    participant Bcrypt as bcrypt
+    participant DB as Prisma + PostgreSQL
+
+    User->>UI: 名前、メール、パスワード入力
+    UI->>UI: パスワード強度チェック<br/>(リアルタイム)
+    User->>UI: フォーム送信
+    UI->>Action: signup(formData)
+
+    Action->>Validation: バリデーション実行
+    Validation-->>Action: 検証結果
+
+    alt バリデーション失敗
+        Action-->>UI: エラーメッセージ
+        UI-->>User: エラー表示
+    else バリデーション成功
+        Action->>DB: メール重複チェック
+        DB-->>Action: 結果
+
+        alt メール既に存在
+            Action-->>UI: "既に登録済み"
+            UI-->>User: エラー表示
+        else メール未使用
+            Action->>Bcrypt: パスワードハッシュ化
+            Bcrypt-->>Action: ハッシュ値
+
+            Action->>DB: トランザクション開始
+            Action->>DB: auth_users作成<br/>(encrypted_password)
+            Action->>DB: public_users作成
+            Action->>DB: トランザクションコミット
+            DB-->>Action: 成功
+
+            Action-->>UI: 登録成功
+            UI->>UI: /loginへリダイレクト
+            UI-->>User: ログインページ表示
+        end
+    end
+```
+
+### ログインフロー
+
+```mermaid
+sequenceDiagram
+    actor User as ユーザー
+    participant UI as /login
+    participant Action as authenticate()
+    participant NextAuth as signIn('credentials')
+    participant AuthTS as /src/auth.ts
+    participant Bcrypt as bcrypt
+    participant DB as Prisma + PostgreSQL
+    participant Session as セッション管理
+
+    User->>UI: メール、パスワード入力
+    User->>UI: ログインボタンクリック
+    UI->>Action: authenticate(formData)
+    Action->>NextAuth: signIn('credentials', formData)
+
+    NextAuth->>AuthTS: Credentials.authorize()
+    AuthTS->>AuthTS: Zodバリデーション
+
+    alt バリデーション失敗
+        AuthTS-->>NextAuth: null
+        NextAuth-->>Action: CredentialsSignin Error
+        Action-->>UI: エラーメッセージ
+        UI-->>User: "メールアドレスまたは<br/>パスワードが正しくありません"
+    else バリデーション成功
+        AuthTS->>DB: getUser(email)
+        DB-->>AuthTS: ユーザー情報
+
+        alt ユーザーなし or パスワードなし
+            AuthTS-->>NextAuth: null
+            NextAuth-->>Action: CredentialsSignin Error
+            Action-->>UI: エラーメッセージ
+            UI-->>User: エラー表示
+        else ユーザー存在
+            AuthTS->>Bcrypt: compare(password, hash)
+            Bcrypt-->>AuthTS: 比較結果
+
+            alt パスワード不一致
+                AuthTS-->>NextAuth: null
+                NextAuth-->>Action: CredentialsSignin Error
+                Action-->>UI: エラーメッセージ
+                UI-->>User: エラー表示
+            else パスワード一致
+                AuthTS-->>NextAuth: userオブジェクト
+                NextAuth->>AuthTS: jwt({ token, user })
+                AuthTS->>AuthTS: token.id = user.id
+                AuthTS-->>NextAuth: token
+
+                NextAuth->>Session: セッション作成
+                Session-->>NextAuth: 成功
+
+                NextAuth-->>Action: 成功
+                Action-->>UI: リダイレクト
+                UI->>UI: /dashboardへ
+                UI-->>User: ダッシュボード表示
+            end
+        end
+    end
+```
+
+---
+
+## 🌐 Google OAuth認証シーケンス図
+
+### 新規ユーザー登録フロー
+
+```mermaid
+sequenceDiagram
+    actor User as ユーザー
+    participant UI as /login or /register
+    participant NextAuth as NextAuth Client
+    participant Google as Google OAuth
+    participant Callback as /api/auth/callback/google
+    participant AuthTS as /src/auth.ts signIn()
+    participant DB as Prisma + PostgreSQL
+    participant Session as セッション管理
+
+    User->>UI: "Googleでログイン"<br/>ボタンクリック
+    UI->>NextAuth: signIn('google', {callbackUrl})
+    NextAuth->>Google: OAuth認証リクエスト
+
+    Google-->>User: Google認証画面表示
+    User->>Google: Googleアカウントで認証
+
+    alt 認証キャンセル
+        Google-->>NextAuth: キャンセル通知
+        NextAuth-->>UI: エラー
+        UI-->>User: "Googleログインに失敗しました"
+    else 認証成功
+        Google->>Callback: リダイレクト<br/>(authorization code)
+        Callback->>Google: トークン交換
+        Google-->>Callback: access_token, user info
+
+        Callback->>AuthTS: signIn({ user, account })
+        AuthTS->>AuthTS: provider === 'google'?
+        AuthTS->>DB: findUnique(email)
+        DB-->>AuthTS: null (新規ユーザー)
+
+        AuthTS->>DB: トランザクション開始
+        Note over AuthTS,DB: 新規ユーザー作成
+        AuthTS->>DB: auth_users作成<br/>(encrypted_password=NULL,<br/>is_sso_user=true)
+        AuthTS->>DB: public_users作成
+        AuthTS->>DB: identities作成<br/>(provider='google',<br/>provider_id, identity_data)
+        AuthTS->>DB: トランザクションコミット
+        DB-->>AuthTS: 成功
+
+        AuthTS-->>Callback: true
+        Callback->>AuthTS: jwt({ token, user })
+        AuthTS->>AuthTS: token.id = user.id
+        AuthTS-->>Callback: token
+
+        Callback->>Session: セッション作成
+        Session-->>Callback: 成功
+
+        Callback-->>UI: リダイレクト
+        UI->>UI: /dashboardへ
+        UI-->>User: ダッシュボード表示
+    end
+```
+
+### 既存ユーザーアカウント連携フロー
+
+```mermaid
+sequenceDiagram
+    actor User as ユーザー<br/>(Credentials登録済み)
+    participant UI as /login
+    participant NextAuth as NextAuth Client
+    participant Google as Google OAuth
+    participant Callback as /api/auth/callback/google
+    participant AuthTS as /src/auth.ts signIn()
+    participant DB as Prisma + PostgreSQL
+    participant Session as セッション管理
+
+    Note over User: user@example.com で<br/>Credentials登録済み
+
+    User->>UI: "Googleでログイン"<br/>ボタンクリック
+    UI->>NextAuth: signIn('google', {callbackUrl})
+    NextAuth->>Google: OAuth認証リクエスト
+
+    Google-->>User: Google認証画面表示
+    User->>Google: 同じメールアドレスの<br/>Googleアカウントで認証
+    Google->>Callback: リダイレクト
+    Callback->>Google: トークン交換
+    Google-->>Callback: access_token, user info
+
+    Callback->>AuthTS: signIn({ user, account })
+    AuthTS->>AuthTS: provider === 'google'?
+    AuthTS->>DB: findUnique(email)
+    DB-->>AuthTS: existingAuthUser<br/>(Credentials登録済み)
+
+    Note over AuthTS,DB: 既存ユーザー検出
+    AuthTS->>DB: identities.findUnique(<br/>provider_id, provider)
+    DB-->>AuthTS: null (未連携)
+
+    Note over AuthTS,DB: アカウント連携処理
+    AuthTS->>DB: identities.create({<br/>provider='google',<br/>user_id,<br/>provider_id,<br/>identity_data})
+    DB-->>AuthTS: 成功
+
+    AuthTS->>DB: auth_users.update(<br/>is_sso_user=true)
+    DB-->>AuthTS: 成功
+
+    AuthTS-->>Callback: true
+    Callback->>AuthTS: jwt({ token, user })
+    AuthTS->>AuthTS: token.id = existingAuthUser.id
+    AuthTS-->>Callback: token
+
+    Callback->>Session: セッション作成
+    Session-->>Callback: 成功
+
+    Callback-->>UI: リダイレクト
+    UI->>UI: /dashboardへ
+    UI-->>User: ダッシュボード表示
+
+    Note over User,DB: 次回以降、Credentials/Google<br/>どちらでもログイン可能
+```
+
+---
+
+## 🔄 アカウント連携状態遷移図
+
+```mermaid
+stateDiagram-v2
+    [*] --> Unregistered: ユーザー初回訪問
+
+    Unregistered --> CredentialsOnly: メール/パスワード登録
+    Unregistered --> GoogleOnly: Google登録
+
+    CredentialsOnly --> Linked: Googleログイン(同一メール)
+    GoogleOnly --> Linked: メール/パスワード設定(将来機能)
+
+    state CredentialsOnly {
+        [*] --> HasPassword
+    }
+    note right of HasPassword
+        encrypted_password: あり
+        is_sso_user: false
+        identities: なし
+    end note
+
+    state GoogleOnly {
+        [*] --> NoPassword
+    }
+    note right of NoPassword
+        encrypted_password: NULL
+        is_sso_user: true
+        identities: Google
+    end note
+
+    state Linked {
+        [*] --> BothMethods
+    }
+    note right of BothMethods
+        encrypted_password: あり
+        is_sso_user: true
+        identities: Google
+        ログイン方法: 両方可能
+    end note
+
+    CredentialsOnly --> [*]: ログアウト
+    GoogleOnly --> [*]: ログアウト
+    Linked --> [*]: ログアウト
+
+```
+
+---
+
+## 🗂️ データベーストランザクションフロー図
+
+### 新規Google OAuth ユーザー作成
+
+```mermaid
+flowchart LR
+    Start([トランザクション開始]) --> Step1[auth_users作成]
+    Step1 --> Step1Details{encrypted_password: NULL<br/>is_sso_user: true<br/>email_confirmed_at: NOW}
+
+    Step1Details --> Step2[public_users作成]
+    Step2 --> Step2Details{同じUUID<br/>name: Google名<br/>email: Googleメール}
+
+    Step2Details --> Step3[identities作成]
+    Step3 --> Step3Details{provider: 'google'<br/>provider_id: GoogleアカウントID<br/>identity_data: JSON}
+
+    Step3Details --> Commit{コミット成功?}
+    Commit -->|Success| Success([ユーザー作成完了])
+    Commit -->|Failure| Rollback([全てロールバック])
+
+    Rollback --> Error[エラーログ出力]
+    Error --> End([ログイン失敗])
+
+    Success --> SessionCreate[セッション作成]
+    SessionCreate --> Dashboard([/dashboardへ])
+
+    style Step1 fill:#FFE4B5
+    style Step2 fill:#FFE4B5
+    style Step3 fill:#FFE4B5
+    style Success fill:#90EE90
+    style Rollback fill:#FFB6C1
+```
+
+### 既存ユーザーアカウント連携
+
+```mermaid
+flowchart LR
+    Start([既存ユーザー検出]) --> Check1{identitiesレコード<br/>存在確認}
+
+    Check1 -->|既に連携済み| Skip([処理スキップ])
+    Check1 -->|未連携| Step1[identities作成]
+
+    Step1 --> Step1Details{provider: 'google'<br/>provider_id: GoogleアカウントID<br/>user_id: 既存ユーザーID<br/>identity_data: JSON}
+
+    Step1Details --> Step2[auth_users更新]
+    Step2 --> Step2Details{is_sso_user: true}
+
+    Step2Details --> Success([アカウント連携完了])
+    Skip --> Success
+
+    Success --> SessionCreate[セッション作成]
+    SessionCreate --> Dashboard([/dashboardへ])
+
+    style Step1 fill:#FFE4B5
+    style Step2 fill:#FFE4B5
+    style Success fill:#90EE90
+```
+
+---
+
+## 🔐 セッション管理フロー
+
+```mermaid
+flowchart TD
+    Login([ログイン成功]) --> CreateJWT[JWTトークン生成]
+    CreateJWT --> AddUserID[token.id = user.id]
+    AddUserID --> CreateSession[セッションレコード作成]
+
+    CreateSession --> SessionDB[(Database<br/>sessions テーブル)]
+    SessionDB --> SetCookie[Cookie設定<br/>next-auth.session-token]
+
+    SetCookie --> User([ユーザーへ返却])
+
+    User --> Request{リクエスト}
+    Request --> AuthFunc[authサーバーコンポーネント]
+    Request --> UseSession[useSessionクライアントコンポーネント]
+
+    AuthFunc --> VerifyJWT[JWTトークン検証]
+    UseSession --> VerifyJWT
+
+    VerifyJWT --> CheckSession{セッション有効?}
+    CheckSession -->|有効| GetUserInfo[ユーザー情報取得]
+    CheckSession -->|無効| Redirect[/loginへリダイレクト/]
+
+    GetUserInfo --> AccessGranted([アクセス許可])
+
+    AccessGranted --> UserAction{ユーザー操作}
+    UserAction -->|継続| Request
+    UserAction -->|ログアウト| Logout[signOut]
+
+    Logout --> DeleteSession[セッション削除]
+    DeleteSession --> ClearCookie[Cookie削除]
+    ClearCookie --> LoginPage([/loginへリダイレクト/])
+
+    style CreateSession fill:#87CEEB
+    style AccessGranted fill:#90EE90
+    style Redirect fill:#FFB6C1
+
+```
+
+---
+
+## 🛡️ アクセス制御フロー（Middleware）
+
+```mermaid
+flowchart TD
+    Request([リクエスト受信]) --> CheckURL{URLパス確認}
+
+    CheckURL -->|/dashboard/*| RequireAuth{認証済み?}
+    CheckURL -->|/login, /register| CheckLogged{ログイン済み?}
+    CheckURL -->|その他| AllowAccess([アクセス許可])
+
+    RequireAuth -->|Yes| AllowAccess
+    RequireAuth -->|No| RedirectLogin[/loginへリダイレクト/]
+
+    CheckLogged -->|Yes| RedirectDashboard[/dashboardへリダイレクト/]
+    CheckLogged -->|No| AllowAccess
+
+    AllowAccess --> Response([レスポンス返却])
+    RedirectLogin --> Response
+    RedirectDashboard --> Response
+
+    style AllowAccess fill:#90EE90
+    style RedirectLogin fill:#FFB6C1
+    style RedirectDashboard fill:#87CEEB
+```
+
+---
+
+## 📋 エラーハンドリングフロー
+
+```mermaid
+flowchart TD
+    Start([認証処理開始]) --> TryCatch{try-catch}
+
+    TryCatch -->|Success| ProcessAuth[認証処理実行]
+    TryCatch -->|Error| CatchError[エラーキャッチ]
+
+    ProcessAuth --> AuthResult{認証結果}
+
+    AuthResult -->|Success| CreateSession([セッション作成])
+    AuthResult -->|CredentialsSignin| Error1[メールアドレスまたは<br/>パスワードが正しくありません]
+    AuthResult -->|OAuthSignin| Error2[OAuth認証に失敗しました]
+    AuthResult -->|CallbackRouteError| Error3[予期しないエラーが<br/>発生しました]
+
+    CatchError --> LogError[console.error]
+    LogError --> Error4[エラーメッセージ生成]
+
+    Error1 --> DisplayError([UIにエラー表示])
+    Error2 --> DisplayError
+    Error3 --> DisplayError
+    Error4 --> DisplayError
+
+    DisplayError --> RetryPrompt([ユーザーに再試行促す])
+    CreateSession --> Dashboard([/dashboardへ])
+
+    style CreateSession fill:#90EE90
+    style DisplayError fill:#FFB6C1
+    style LogError fill:#FFA500
+```
+
+---

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -2,18 +2,24 @@
 
 このプロジェクトでは、`next-auth` (Auth.js) v5 を使用して認証システムを構築しています。
 
+> 📊 **フロー図・シーケンス図**: 認証システムの視覚的な理解には [認証システム フロー図・シーケンス図](./authentication-diagrams.md) を参照してください。
+
 ## 概要
 
-- **プロバイダー**: `Credentials` プロバイダーのみを使用し、メールアドレスとパスワードによる認証を実装しています。
+- **プロバイダー**:
+  - `Credentials` プロバイダー: メールアドレスとパスワードによる認証
+  - `Google` プロバイダー: GoogleアカウントでのOAuth認証
 - **データベース**: `Supabase` の `PostgreSQL` を使用し、ユーザー情報は `auth_users` テーブルに格納されます。
 - **パスワードハッシュ化**: `bcrypt` を使用してパスワードを安全にハッシュ化し、保存・比較しています。
+- **アカウント連携**: メールアドレスで既存アカウントと自動連携
 
 ## 主要ファイル
 
-- `src/auth.ts`: `next-auth` のメイン設定ファイル。`Credentials` プロバイダーの `authorize` ロジックを定義しています。
+- `src/auth.ts`: `next-auth` のメイン設定ファイル。`Credentials`と`Google`プロバイダーの設定、`signIn`コールバックでのアカウント連携ロジックを定義しています。
 - `src/auth.config.ts`: 認証に関する設定（ログインページのパス、リダイレクト処理、アクセス制御など）を定義しています。
 - `src/app/api/auth/[...nextauth]/route.ts`: `next-auth` が使用するAPIルートです。
-- `src/lib/actions.ts`: ユーザー登録 (`registerUser`) やログイン (`authenticate`) のためのサーバーアクションを定義しています。
+- `src/lib/actions.ts`: ユーザー登録 (`signup`) やログイン (`authenticate`) のためのサーバーアクションを定義しています。
+- `src/types/next-auth.d.ts`: Next-Authの型拡張（セッション/JWTトークンにユーザーIDを追加）。
 
 ## 認証フロー
 
@@ -40,9 +46,106 @@
 - `/dashboard` で始まるパスへのアクセスには認証が必要です。未認証のユーザーはログインページ (`/login`) にリダイレクトされます。
 - 認証済みのユーザーがログインページ (`/login`) や登録ページ (`/register`) にアクセスすると、ダッシュボード (`/dashboard`) に自動的にリダイレクトされます。
 
+### 4. Google OAuth認証
+
+1. ユーザーがログインページ (`/login`) または登録ページ (`/register`) で「Googleでログイン」ボタンをクリックします。
+2. `signIn('google', { callbackUrl: '/dashboard' })` が呼び出され、Google OAuth画面へリダイレクトされます。
+3. ユーザーがGoogleアカウントで認証します。
+4. `/api/auth/callback/google` へリダイレクトされ、`src/auth.ts` の `signIn` コールバックが実行されます。
+5. **既存ユーザーの場合**:
+   - メールアドレスで既存ユーザーを検索
+   - `identities` テーブルに新規レコード追加（アカウント連携）
+   - `auth_users.is_sso_user` を `true` に更新
+6. **新規ユーザーの場合**:
+   - Prismaトランザクションで `auth_users`, `public_users`, `identities` を同時作成
+   - `encrypted_password` は `NULL`（パスワード不要）
+7. セッション作成、`/dashboard` へリダイレクト
+
+## アカウント連携
+
+### メールアドレスによる自動連携
+
+`allowDangerousEmailAccountLinking: true` 設定により、同一メールアドレスのアカウントを自動連携します。
+
+**例**:
+1. ユーザーがメール/パスワードで登録（`user@example.com`）
+2. 後日、同じメールアドレスのGoogleアカウントでログイン
+3. 既存アカウントと自動連携される（`identities` テーブルに新規レコード追加）
+4. 次回以降、メール/パスワードとGoogleどちらでもログイン可能
+
+### セキュリティ考慮事項
+
+- **GoogleのOAuth認証**: Google側でメール所有権が確認されているため、なりすましリスクは低い
+- **残存リスク**: 攻撃者がターゲットのメールアドレスのGoogleアカウントを持っている場合のみ影響
+- **将来対応**: 独自のメール検証機能追加、二段階認証実装
+
+## データベーススキーマ
+
+### `auth.users` (auth_users)
+
+- `encrypted_password`: `String?` (NULL許可、OAuth専用ユーザー対応)
+- `is_sso_user`: `Boolean` (デフォルト: false、OAuthユーザー識別)
+- `email_confirmed_at`: OAuth認証時に自動設定
+
+### `auth.identities`
+
+プロバイダー別の認証情報を管理:
+- `provider_id`: GoogleアカウントのユニークID
+- `provider`: `"google"`
+- `identity_data`: JSON（email, name, pictureを保存）
+- ユニーク制約: `(provider_id, provider)`
+
+### `public.users` (public_users)
+
+アプリケーション用ユーザープロファイル（`auth_users.id` と同じUUIDを使用）
+
+## 環境変数
+
+### Google OAuth設定
+
+```bash
+# Google Cloud Consoleで取得
+AUTH_GOOGLE_ID="your_google_client_id"
+AUTH_GOOGLE_SECRET="your_google_client_secret"
+
+# Auth.js基本設定
+AUTH_SECRET="npx auth secretで生成"
+AUTH_URL="http://localhost:3000"  # 本番環境では実際のURL
+```
+
+### Google Cloud Console設定
+
+1. **OAuth 2.0クライアントを作成**:
+   - [Google Cloud Console](https://console.cloud.google.com/) にアクセス
+   - 「APIとサービス」→「認証情報」→「認証情報を作成」→「OAuth 2.0 クライアントID」
+
+2. **承認済みリダイレクトURI**:
+   ```
+   http://localhost:3000/api/auth/callback/google
+   https://yourdomain.com/api/auth/callback/google
+   ```
+
+3. **スコープ**: `email`, `profile`（デフォルト）
+
 ## フロントエンドでの利用
 
 - **`AuthProvider`**: `src/components/providers/auth-provider.tsx` で `SessionProvider` をラップし、アプリケーション全体でセッション情報を提供します。
 - **`useSession`**: クライアントコンポーネントでセッション情報を取得するために使用します。
 - **`auth()`**: サーバーコンポーネントやサーバーアクションでセッション情報を取得するために使用します。
 - **`signIn` / `signOut`**: ログイン・ログアウト処理を実行するために使用します。
+
+### Google OAuth ログイン実装例
+
+```typescript
+'use client';
+import { signIn } from 'next-auth/react';
+
+const handleGoogleSignIn = async () => {
+  try {
+    await signIn('google', { callbackUrl: '/dashboard' });
+  } catch (error) {
+    console.error('Google sign-in error:', error);
+    // エラーハンドリング
+  }
+};
+```

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,17 +1,29 @@
 'use client';
 
 import { authenticate } from '@/lib/actions';
+import { signIn } from 'next-auth/react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import Link from 'next/link';
-import { useActionState } from 'react';
+import { useActionState, useState } from 'react';
 import { useFormStatus } from 'react-dom';
 import { AlertCircle } from 'lucide-react';
 
 export default function LoginPage() {
   const [errorMessage, dispatch] = useActionState(authenticate, undefined);
+  const [googleError, setGoogleError] = useState<string | undefined>(undefined);
+
+  const handleGoogleSignIn = async () => {
+    try {
+      setGoogleError(undefined);
+      await signIn('google', { callbackUrl: '/dashboard' });
+    } catch (error) {
+      console.error('Google sign-in error:', error);
+      setGoogleError('Googleログインに失敗しました。時間をおいて再度お試しください。');
+    }
+  };
 
   return (
     <div className="flex items-center justify-center min-h-screen bg-gray-100 dark:bg-gray-950">
@@ -49,9 +61,53 @@ export default function LoginPage() {
                 </div>
               )}
               <LoginButton />
-              <Button variant="outline" className="w-full" disabled>
+
+              <div className="relative">
+                <div className="absolute inset-0 flex items-center">
+                  <span className="w-full border-t" />
+                </div>
+                <div className="relative flex justify-center text-xs uppercase">
+                  <span className="bg-background px-2 text-muted-foreground">または</span>
+                </div>
+              </div>
+
+              <Button
+                type="button"
+                variant="outline"
+                className="w-full"
+                onClick={handleGoogleSignIn}
+              >
+                <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24">
+                  <path
+                    fill="currentColor"
+                    d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+                  />
+                  <path
+                    fill="currentColor"
+                    d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                  />
+                  <path
+                    fill="currentColor"
+                    d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+                  />
+                  <path
+                    fill="currentColor"
+                    d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+                  />
+                </svg>
                 Googleでログイン
               </Button>
+
+              {googleError && (
+                <div
+                  className="flex items-center space-x-2 text-sm text-red-500"
+                  aria-live="polite"
+                  aria-atomic="true"
+                >
+                  <AlertCircle className="h-4 w-4" />
+                  <p>{googleError}</p>
+                </div>
+              )}
             </div>
             <div className="mt-4 text-center text-sm">
               アカウントをお持ちでないですか？{' '}

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { signup } from '@/lib/actions';
+import { signIn } from 'next-auth/react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -15,6 +16,17 @@ import { AlertCircle } from 'lucide-react';
 export default function RegisterPage() {
   const [errorMessage, dispatch] = useActionState(signup, undefined);
   const [password, setPassword] = useState('');
+  const [googleError, setGoogleError] = useState<string | undefined>(undefined);
+
+  const handleGoogleSignIn = async () => {
+    try {
+      setGoogleError(undefined);
+      await signIn('google', { callbackUrl: '/dashboard' });
+    } catch (error) {
+      console.error('Google sign-in error:', error);
+      setGoogleError('Googleログインに失敗しました。時間をおいて再度お試しください。');
+    }
+  };
 
   return (
     <div className="flex items-center justify-center min-h-screen bg-gray-100 dark:bg-gray-950">
@@ -66,6 +78,53 @@ export default function RegisterPage() {
                 </div>
               )}
               <SignupButton />
+
+              <div className="relative">
+                <div className="absolute inset-0 flex items-center">
+                  <span className="w-full border-t" />
+                </div>
+                <div className="relative flex justify-center text-xs uppercase">
+                  <span className="bg-background px-2 text-muted-foreground">または</span>
+                </div>
+              </div>
+
+              <Button
+                type="button"
+                variant="outline"
+                className="w-full"
+                onClick={handleGoogleSignIn}
+              >
+                <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24">
+                  <path
+                    fill="currentColor"
+                    d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+                  />
+                  <path
+                    fill="currentColor"
+                    d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                  />
+                  <path
+                    fill="currentColor"
+                    d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+                  />
+                  <path
+                    fill="currentColor"
+                    d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+                  />
+                </svg>
+                Googleで登録
+              </Button>
+
+              {googleError && (
+                <div
+                  className="flex items-center space-x-2 text-sm text-red-500"
+                  aria-live="polite"
+                  aria-atomic="true"
+                >
+                  <AlertCircle className="h-4 w-4" />
+                  <p>{googleError}</p>
+                </div>
+              )}
             </div>
             <div className="mt-4 text-center text-sm">
               既にアカウントをお持ちですか？{' '}

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,9 +1,11 @@
 import NextAuth from 'next-auth';
 import Credentials from 'next-auth/providers/credentials';
+import Google from 'next-auth/providers/google';
 import { z } from 'zod';
 import prisma from '@/lib/prisma';
 import bcrypt from 'bcrypt';
 import { authConfig } from './auth.config';
+import { randomUUID } from 'crypto';
 
 async function getUser(email: string) {
   try {
@@ -23,6 +25,11 @@ async function getUser(email: string) {
 export const { handlers, auth, signIn, signOut } = NextAuth({
   ...authConfig,
   providers: [
+    Google({
+      clientId: process.env.AUTH_GOOGLE_ID!,
+      clientSecret: process.env.AUTH_GOOGLE_SECRET!,
+      allowDangerousEmailAccountLinking: true,
+    }),
     Credentials({
       async authorize(credentials) {
         const parsedCredentials = z
@@ -53,6 +60,111 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
   ],
   callbacks: {
     ...authConfig.callbacks,
+    async signIn({ user, account }) {
+      // Credentials認証の場合はスキップ（既存動作維持）
+      if (account?.provider === 'credentials') {
+        return true;
+      }
+
+      // Google認証の場合のみ処理
+      if (account?.provider === 'google' && user.email) {
+        const email = user.email.toLowerCase().trim();
+
+        try {
+          // 既存ユーザーをメールアドレスで検索
+          const existingAuthUser = await prisma.auth_users.findUnique({
+            where: { email },
+          });
+
+          if (existingAuthUser) {
+            // 既存ユーザーが存在する場合：アカウント連携
+            // identitiesレコードが存在するか確認
+            const existingIdentity = await prisma.identities.findUnique({
+              where: {
+                provider_id_provider: {
+                  provider_id: account.providerAccountId,
+                  provider: 'google',
+                },
+              },
+            });
+
+            if (!existingIdentity) {
+              // identitiesレコードを作成（アカウント連携）
+              await prisma.identities.create({
+                data: {
+                  provider_id: account.providerAccountId,
+                  provider: 'google',
+                  user_id: existingAuthUser.id,
+                  identity_data: {
+                    email: user.email,
+                    name: user.name,
+                    picture: user.image,
+                  },
+                  last_sign_in_at: new Date(),
+                },
+              });
+
+              // is_sso_userフラグを更新
+              await prisma.auth_users.update({
+                where: { id: existingAuthUser.id },
+                data: { is_sso_user: true },
+              });
+            }
+
+            return true;
+          } else {
+            // 新規ユーザー作成（トランザクション処理）
+            const userId = randomUUID();
+
+            await prisma.$transaction(async (tx) => {
+              // 1. auth_usersレコード作成
+              await tx.auth_users.create({
+                data: {
+                  id: userId,
+                  email,
+                  encrypted_password: null, // パスワード不要
+                  aud: 'authenticated',
+                  role: 'authenticated',
+                  is_sso_user: true,
+                  email_confirmed_at: new Date(), // OAuth認証済みなのでメール確認不要
+                },
+              });
+
+              // 2. public_usersレコード作成
+              await tx.public_users.create({
+                data: {
+                  id: userId,
+                  name: user.name || 'Googleユーザー',
+                  email,
+                },
+              });
+
+              // 3. identitiesレコード作成
+              await tx.identities.create({
+                data: {
+                  provider_id: account.providerAccountId,
+                  provider: 'google',
+                  user_id: userId,
+                  identity_data: {
+                    email: user.email,
+                    name: user.name,
+                    picture: user.image,
+                  },
+                  last_sign_in_at: new Date(),
+                },
+              });
+            });
+
+            return true;
+          }
+        } catch (error) {
+          console.error('Google sign-in error:', error);
+          return false; // ログイン失敗
+        }
+      }
+
+      return true;
+    },
     async jwt({ token, user }) {
       if (user) {
         token.id = user.id;

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,0 +1,23 @@
+import 'next-auth';
+import 'next-auth/jwt';
+
+declare module 'next-auth' {
+  interface User {
+    id: string;
+  }
+
+  interface Session {
+    user: {
+      id: string;
+      name?: string | null;
+      email?: string | null;
+      image?: string | null;
+    };
+  }
+}
+
+declare module 'next-auth/jwt' {
+  interface JWT {
+    id: string;
+  }
+}


### PR DESCRIPTION
## 対応
- 新規登録 / ログイン にGoogleで登録、ログインできるように
1. 環境変数設定
    - .env.exampleにAUTH_GOOGLE_IDとAUTH_GOOGLE_SECRETが既に記載されていることを確認
  2. 型定義作成 (src/types/next-auth.d.ts)
    - セッション/JWTトークンにユーザーIDフィールドを追加
    - TypeScript型安全性を向上
  3. Googleプロバイダー追加 (src/auth.ts)
    - Googleプロバイダーを設定
    - signInコールバックで既存ユーザー確認とアカウント連携ロジックを実装
    - 新規Googleユーザーはauth_users, public_users, identitiesをトランザクションで同時作成
    - 既存ユーザーはidentitiesテーブルに新規レコード追加
  4. UIコンポーネント更新
    - /src/app/login/page.tsx: Googleログインボタンを追加、エラーハンドリング実装
    - /src/app/register/page.tsx: Googleログインボタンを追加、エラーハンドリング実装
    - 区切り線とGoogleロゴ付きボタンで視覚的に統一
  5. ドキュメント更新
    - docs/authentication.md: Google OAuth認証フロー、アカウント連携、環境変数設定、実装例を追加
    - docs/authentication-diagrams.md: 認証周りのダイアグラム追加

  ### 📋 実装の特徴
  - アカウント連携: 同一メールアドレスで既存アカウント（Credentials）とGoogleアカウントを自動連携
  - パスワード不要: OAuth専用ユーザーはencrypted_password = NULLで管理
  - トランザクション処理: Prismaの$transactionで整合性を保証
  - セキュリティ: GoogleのOAuth認証を信頼し、CSRF対策も自動対応