### PR TITLE
#37 WeatherAPIの実装

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,10 @@
 # Database
 DATABASE_URL=postgresql://FishingPostgres:FishingPostgres@localhost:5432/fishing_app
 
+# Redis (Upstash)
+UPSTASH_REDIS_REST_URL=your_upstash_redis_url
+UPSTASH_REDIS_REST_TOKEN=your_upstash_redis_token
+
 # Auth
 AUTH_SECRET=your_auth_secret_here
 AUTH_URL=http://localhost:3000
@@ -14,13 +18,20 @@ AUTH_URL=http://localhost:3000
 AUTH_GOOGLE_ID=your_google_client_id
 AUTH_GOOGLE_SECRET=your_google_client_secret
 
-# External APIs
-OPENWEATHERMAP_API_KEY=your_openweathermap_api_key
-NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=your_google_maps_api_key
+# ============================================
+# External APIs（外部APIキー）
+# ============================================
 
-# Redis (Upstash)
-UPSTASH_REDIS_REST_URL=your_upstash_redis_url
-UPSTASH_REDIS_REST_TOKEN=your_upstash_redis_token
+# [必須] OpenWeatherMap API
+# 天気データ（気温、湿度、気圧、風速など）の取得に必要
+# 取得方法: https://openweathermap.org/api
+OPENWEATHERMAP_API_KEY=your_openweathermap_api_key
+
+# [必須] Google Maps API
+# 位置情報検索（ジオコーディング）に必要
+# 接頭辞 NEXT_PUBLIC_ は必須（ブラウザで使用）
+# 取得方法: https://console.cloud.google.com/
+NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=your_google_maps_api_key
 
 # Docker (開発環境用)
 POSTGRES_USER=FishingPostgres

--- a/src/app/api/weather/route.ts
+++ b/src/app/api/weather/route.ts
@@ -1,0 +1,144 @@
+/**
+ * Weather API エンドポイント
+ * GET /api/weather?lat={緯度}&lon={経度}
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getCurrentWeather, getForecast, isWeatherApiConfigured } from '@/lib/openWeatherService';
+import { ApiError } from '@/lib/apiClient';
+import { logApiError } from '@/lib/apiErrorUtils';
+
+/**
+ * 座標パラメータのバリデーション
+ */
+function validateCoordinates(
+  lat: string | null,
+  lon: string | null,
+): { lat: number; lon: number } | { error: string } {
+  if (!lat || !lon) {
+    return { error: '緯度(lat)と経度(lon)は必須パラメータです' };
+  }
+
+  const latNum = parseFloat(lat);
+  const lonNum = parseFloat(lon);
+
+  if (isNaN(latNum) || isNaN(lonNum)) {
+    return { error: '緯度と経度は有効な数値である必要があります' };
+  }
+
+  if (latNum < -90 || latNum > 90) {
+    return { error: '緯度は-90から90の範囲である必要があります' };
+  }
+
+  if (lonNum < -180 || lonNum > 180) {
+    return { error: '経度は-180から180の範囲である必要があります' };
+  }
+
+  return { lat: latNum, lon: lonNum };
+}
+
+/**
+ * GET /api/weather
+ * クエリパラメータ:
+ * - lat: 緯度（必須）
+ * - lon: 経度（必須）
+ * - type: 'current' | 'forecast'（デフォルト: 'current'）
+ * - lang: 言語コード（デフォルト: 'ja'）
+ * - units: 'standard' | 'metric' | 'imperial'（デフォルト: 'metric'）
+ * - skipCache: キャッシュをスキップするか（デフォルト: false）
+ */
+export async function GET(request: NextRequest) {
+  // APIキーのチェック
+  if (!isWeatherApiConfigured()) {
+    console.error('[Weather API] OPENWEATHERMAP_API_KEY is not configured');
+    return NextResponse.json(
+      { error: 'Weather API is not configured', code: 'API_NOT_CONFIGURED' },
+      { status: 503 },
+    );
+  }
+
+  const searchParams = request.nextUrl.searchParams;
+
+  // 座標パラメータの取得とバリデーション
+  const coordResult = validateCoordinates(searchParams.get('lat'), searchParams.get('lon'));
+
+  if ('error' in coordResult) {
+    return NextResponse.json({ error: coordResult.error, code: 'INVALID_PARAMS' }, { status: 400 });
+  }
+
+  const { lat, lon } = coordResult;
+
+  // オプションパラメータの取得
+  const type = searchParams.get('type') || 'current';
+  const lang = searchParams.get('lang') || 'ja';
+  const units = (searchParams.get('units') as 'standard' | 'metric' | 'imperial') || 'metric';
+  const skipCache = searchParams.get('skipCache') === 'true';
+
+  // typeパラメータのバリデーション
+  if (type !== 'current' && type !== 'forecast') {
+    return NextResponse.json(
+      { error: 'typeは "current" または "forecast" である必要があります', code: 'INVALID_PARAMS' },
+      { status: 400 },
+    );
+  }
+
+  // unitsパラメータのバリデーション
+  if (!['standard', 'metric', 'imperial'].includes(units)) {
+    return NextResponse.json(
+      {
+        error: 'unitsは "standard", "metric", または "imperial" である必要があります',
+        code: 'INVALID_PARAMS',
+      },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const options = { lang, units, skipCache };
+
+    if (type === 'forecast') {
+      const result = await getForecast(lat, lon, options);
+      return NextResponse.json({
+        success: true,
+        type: 'forecast',
+        ...result,
+      });
+    }
+
+    const result = await getCurrentWeather(lat, lon, options);
+    return NextResponse.json({
+      success: true,
+      type: 'current',
+      ...result,
+    });
+  } catch (error) {
+    // ApiErrorの場合は詳細なエラーレスポンスを返す
+    if (error instanceof ApiError) {
+      logApiError(error, { endpoint: '/api/weather', lat, lon, type });
+
+      const statusCode = error.statusCode || 500;
+
+      return NextResponse.json(
+        {
+          success: false,
+          error: error.message,
+          code: error.type,
+          retryable: error.retryable,
+        },
+        { status: statusCode >= 500 ? 502 : statusCode },
+      );
+    }
+
+    // 予期しないエラー
+    console.error('[Weather API] Unexpected error:', error);
+
+    return NextResponse.json(
+      {
+        success: false,
+        error: '天気データの取得中にエラーが発生しました',
+        code: 'INTERNAL_ERROR',
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -38,6 +38,8 @@ class ApiClient {
   // APIキーをクエリパラメータとして渡すか、ヘッダーで渡すかを指定
   private keyLocation: 'query' | 'header';
   private keyName: string;
+  // APIクライアントが正しく設定されているかを示すフラグ
+  private isConfigured: boolean = true;
 
   // デフォルト設定
   private readonly DEFAULT_TIMEOUT_MS = 10000; // 10秒
@@ -48,11 +50,25 @@ class ApiClient {
     apiKey: string,
     keyLocation: 'query' | 'header' = 'header', // デフォルトはヘッダー
     keyName: string = 'X-API-Key', // デフォルトのヘッダー/クエリ名
+    requireApiKey: boolean = true, // APIキーが必須かどうか
   ) {
     this.baseUrl = baseUrl;
     this.apiKey = apiKey;
     this.keyLocation = keyLocation;
     this.keyName = keyName;
+
+    // APIキーが必要なのに未設定の場合、警告を出して無効化
+    if (requireApiKey && !apiKey) {
+      console.warn(`[ApiClient] API key not configured for ${baseUrl}. Requests will fail.`);
+      this.isConfigured = false;
+    }
+  }
+
+  /**
+   * APIクライアントが正しく設定されているかチェック
+   */
+  public isAvailable(): boolean {
+    return this.isConfigured;
   }
 
   /**
@@ -125,6 +141,16 @@ class ApiClient {
     options: RequestOptions = {},
     attempt: number = 0,
   ): Promise<T> {
+    // APIクライアントが無効な場合、即座にエラーをスロー
+    if (!this.isConfigured) {
+      throw new ApiError(
+        'API client is not configured. Please check your environment variables.',
+        ApiErrorType.CLIENT_ERROR,
+        undefined,
+        false, // リトライ不可
+      );
+    }
+
     const timeout = options.timeout ?? this.DEFAULT_TIMEOUT_MS;
     const maxRetries = options.retries ?? this.DEFAULT_RETRIES;
 
@@ -265,6 +291,7 @@ export const openWeatherMapClient = new ApiClient(
   process.env.OPENWEATHERMAP_API_KEY || '',
   'query', // OpenWeatherMapはキーをクエリ(appid)で渡す
   'appid',
+  true, // APIキー必須
 );
 
 export const googleMapsClient = new ApiClient(
@@ -272,10 +299,14 @@ export const googleMapsClient = new ApiClient(
   process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY || '',
   'query', // Google Maps APIはキーをクエリ(key)で渡す
   'key',
+  true, // APIキー必須
 );
 
 // tide736.net のAPIクライアントインスタンスをエクスポート
 export const tide736Client = new ApiClient(
   'https://api.tide736.net/api', // tide736.net のベースURL
-  '', // APIキーは不要
+  '',
+  'query',
+  '',
+  false, // APIキー不要
 );

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -1,0 +1,191 @@
+/**
+ * Upstash Redis キャッシュユーティリティ
+ * @see https://docs.upstash.com/redis/sdks/ts/getstarted
+ */
+
+// キャッシュのTTL定数（秒単位）
+export const CACHE_TTL = {
+  WEATHER: 30 * 60, // 30分
+  TIDE: 6 * 60 * 60, // 6時間
+  LOCATION: 24 * 60 * 60, // 24時間
+} as const;
+
+// キャッシュキーのプレフィックス
+export const CACHE_PREFIX = {
+  WEATHER: 'weather',
+  TIDE: 'tide',
+  LOCATION: 'location',
+} as const;
+
+interface CacheConfig {
+  url: string;
+  token: string;
+}
+
+/**
+ * Upstash Redis REST APIを使用したキャッシュクライアント
+ */
+class CacheClient {
+  private config: CacheConfig | null = null;
+
+  constructor() {
+    const url = process.env.UPSTASH_REDIS_REST_URL;
+    const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+
+    if (url && token) {
+      this.config = { url, token };
+    } else {
+      console.warn('[Cache] Upstash Redis is not configured. Caching disabled.');
+    }
+  }
+
+  /**
+   * キャッシュが利用可能かどうか
+   */
+  public isAvailable(): boolean {
+    return this.config !== null;
+  }
+
+  /**
+   * Redis REST APIにコマンドを送信
+   */
+  private async executeCommand<T>(command: string[]): Promise<T | null> {
+    if (!this.config) {
+      return null;
+    }
+
+    try {
+      const response = await fetch(`${this.config.url}`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${this.config.token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(command),
+      });
+
+      if (!response.ok) {
+        console.error(`[Cache] Redis command failed: ${response.status}`);
+        return null;
+      }
+
+      const data = await response.json();
+      return data.result as T;
+    } catch (error) {
+      console.error('[Cache] Redis command error:', error);
+      return null;
+    }
+  }
+
+  /**
+   * キャッシュからデータを取得
+   * @param key キャッシュキー
+   * @returns キャッシュされたデータ、またはnull
+   */
+  public async get<T>(key: string): Promise<T | null> {
+    const result = await this.executeCommand<string>(['GET', key]);
+
+    if (result === null) {
+      return null;
+    }
+
+    try {
+      return JSON.parse(result) as T;
+    } catch {
+      console.error(`[Cache] Failed to parse cached data for key: ${key}`);
+      return null;
+    }
+  }
+
+  /**
+   * キャッシュにデータを保存
+   * @param key キャッシュキー
+   * @param value 保存するデータ
+   * @param ttlSeconds TTL（秒）
+   */
+  public async set<T>(key: string, value: T, ttlSeconds: number): Promise<boolean> {
+    const serialized = JSON.stringify(value);
+    const result = await this.executeCommand<string>([
+      'SET',
+      key,
+      serialized,
+      'EX',
+      String(ttlSeconds),
+    ]);
+    return result === 'OK';
+  }
+
+  /**
+   * キャッシュからデータを削除
+   * @param key キャッシュキー
+   */
+  public async delete(key: string): Promise<boolean> {
+    const result = await this.executeCommand<number>(['DEL', key]);
+    return result !== null && result > 0;
+  }
+
+  /**
+   * パターンに一致するキーを削除（キャッシュ無効化）
+   * @param pattern キーパターン（例: "weather:*"）
+   */
+  public async deleteByPattern(pattern: string): Promise<number> {
+    // SCAN + DEL でパターン削除（Upstash REST APIでは直接KEYS使用可能）
+    const keys = await this.executeCommand<string[]>(['KEYS', pattern]);
+
+    if (!keys || keys.length === 0) {
+      return 0;
+    }
+
+    let deleted = 0;
+    for (const key of keys) {
+      const success = await this.delete(key);
+      if (success) deleted++;
+    }
+
+    return deleted;
+  }
+}
+
+// シングルトンインスタンス
+export const cache = new CacheClient();
+
+/**
+ * キャッシュキーを生成するヘルパー関数
+ */
+export function generateCacheKey(prefix: string, params: Record<string, string | number>): string {
+  const sortedParams = Object.keys(params)
+    .sort()
+    .map((key) => `${key}:${params[key]}`)
+    .join(':');
+  return `${prefix}:${sortedParams}`;
+}
+
+/**
+ * キャッシュを通してデータを取得するヘルパー関数
+ * キャッシュミス時はfetcherを実行してキャッシュに保存
+ */
+export async function withCache<T>(
+  key: string,
+  ttlSeconds: number,
+  fetcher: () => Promise<T>,
+): Promise<{ data: T; fromCache: boolean }> {
+  // キャッシュから取得を試みる
+  const cached = await cache.get<T>(key);
+
+  if (cached !== null) {
+    console.log(`[Cache] HIT: ${key}`);
+    return { data: cached, fromCache: true };
+  }
+
+  console.log(`[Cache] MISS: ${key}`);
+
+  // fetcherでデータを取得
+  const data = await fetcher();
+
+  // キャッシュに保存（非同期、エラーは無視）
+  cache.set(key, data, ttlSeconds).catch((error) => {
+    console.error(`[Cache] Failed to cache data for key ${key}:`, error);
+  });
+
+  return { data, fromCache: false };
+}

--- a/src/lib/googleMapsClient.ts
+++ b/src/lib/googleMapsClient.ts
@@ -9,6 +9,13 @@ import { googleMapsClient } from './apiClient';
  * @throws APIがエラーを返した場合にエラーをスローします
  */
 export const geocode = async (address: string): Promise<GeocodingResponse> => {
+  // Google Maps APIが正しく設定されているかチェック
+  if (!googleMapsClient.isAvailable()) {
+    throw new Error(
+      'Google Maps API is not configured. Please set NEXT_PUBLIC_GOOGLE_MAPS_API_KEY in your environment variables.',
+    );
+  }
+
   try {
     const data = await googleMapsClient.get<GeocodingResponse>('/geocode/json', {
       params: {

--- a/src/lib/openWeatherService.ts
+++ b/src/lib/openWeatherService.ts
@@ -1,0 +1,236 @@
+/**
+ * OpenWeatherMap APIサービス
+ * 天気情報の取得とキャッシング機能を提供
+ */
+
+import { openWeatherMapClient } from './apiClient';
+import { withCache, generateCacheKey, CACHE_TTL, CACHE_PREFIX } from './cache';
+import type { CurrentWeatherData, ForecastData } from '@/types/weather';
+
+/**
+ * 天気取得時のオプション
+ */
+export interface WeatherOptions {
+  /** 言語コード（デフォルト: ja） */
+  lang?: string;
+  /** 単位系（デフォルト: metric） */
+  units?: 'standard' | 'metric' | 'imperial';
+  /** キャッシュをスキップするか */
+  skipCache?: boolean;
+}
+
+/**
+ * 天気サービスのレスポンス型
+ */
+export interface WeatherResponse<T> {
+  data: T;
+  fromCache: boolean;
+  fetchedAt: string;
+}
+
+/**
+ * アプリケーション用に整形された天気データ
+ */
+export interface FormattedWeatherData {
+  /** 座標 */
+  coordinates: {
+    lat: number;
+    lon: number;
+  };
+  /** 都市名 */
+  cityName: string;
+  /** 国コード */
+  country: string;
+  /** 気温（摂氏） */
+  temperature: number;
+  /** 体感気温 */
+  feelsLike: number;
+  /** 最低気温 */
+  tempMin: number;
+  /** 最高気温 */
+  tempMax: number;
+  /** 湿度（%） */
+  humidity: number;
+  /** 気圧（hPa） */
+  pressure: number;
+  /** 風速（m/s） */
+  windSpeed: number;
+  /** 風向（度） */
+  windDeg: number;
+  /** 突風（m/s） */
+  windGust?: number;
+  /** 雲量（%） */
+  cloudiness: number;
+  /** 視程（m） */
+  visibility: number;
+  /** 天気状態 */
+  weather: {
+    id: number;
+    main: string;
+    description: string;
+    icon: string;
+  };
+  /** 雨量（mm/h） */
+  rain?: number;
+  /** 雪量（mm/h） */
+  snow?: number;
+  /** 日の出時刻 */
+  sunrise: Date;
+  /** 日の入り時刻 */
+  sunset: Date;
+  /** データ取得時刻 */
+  dataTime: Date;
+  /** タイムゾーンオフセット（秒） */
+  timezone: number;
+}
+
+/**
+ * OpenWeatherMap APIからのレスポンスをアプリ用に整形
+ */
+function formatWeatherData(raw: CurrentWeatherData): FormattedWeatherData {
+  return {
+    coordinates: {
+      lat: raw.coord.lat,
+      lon: raw.coord.lon,
+    },
+    cityName: raw.name,
+    country: raw.sys.country,
+    temperature: raw.main.temp,
+    feelsLike: raw.main.feels_like,
+    tempMin: raw.main.temp_min ?? raw.main.temp,
+    tempMax: raw.main.temp_max ?? raw.main.temp,
+    humidity: raw.main.humidity,
+    pressure: raw.main.pressure,
+    windSpeed: raw.wind.speed,
+    windDeg: raw.wind.deg,
+    windGust: raw.wind.gust,
+    cloudiness: raw.clouds.all,
+    visibility: raw.visibility,
+    weather: {
+      id: raw.weather[0].id,
+      main: raw.weather[0].main,
+      description: raw.weather[0].description,
+      icon: raw.weather[0].icon,
+    },
+    rain: raw.rain?.['1h'],
+    snow: raw.snow?.['1h'],
+    sunrise: new Date(raw.sys.sunrise * 1000),
+    sunset: new Date(raw.sys.sunset * 1000),
+    dataTime: new Date(raw.dt * 1000),
+    timezone: raw.timezone,
+  };
+}
+
+/**
+ * 座標から現在の天気を取得
+ * @param lat 緯度
+ * @param lon 経度
+ * @param options オプション
+ */
+export async function getCurrentWeather(
+  lat: number,
+  lon: number,
+  options: WeatherOptions = {},
+): Promise<WeatherResponse<FormattedWeatherData>> {
+  const { lang = 'ja', units = 'metric', skipCache = false } = options;
+
+  // 座標を小数点2桁に丸める（キャッシュ効率化）
+  const roundedLat = Math.round(lat * 100) / 100;
+  const roundedLon = Math.round(lon * 100) / 100;
+
+  const cacheKey = generateCacheKey(CACHE_PREFIX.WEATHER, {
+    lat: roundedLat,
+    lon: roundedLon,
+    lang,
+    units,
+  });
+
+  const fetchWeather = async (): Promise<FormattedWeatherData> => {
+    const rawData = await openWeatherMapClient.get<CurrentWeatherData>('/weather', {
+      params: {
+        lat: String(lat),
+        lon: String(lon),
+        lang,
+        units,
+      },
+    });
+    return formatWeatherData(rawData);
+  };
+
+  if (skipCache) {
+    const data = await fetchWeather();
+    return {
+      data,
+      fromCache: false,
+      fetchedAt: new Date().toISOString(),
+    };
+  }
+
+  const { data, fromCache } = await withCache(cacheKey, CACHE_TTL.WEATHER, fetchWeather);
+
+  return {
+    data,
+    fromCache,
+    fetchedAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * 座標から5日間の天気予報を取得
+ * @param lat 緯度
+ * @param lon 経度
+ * @param options オプション
+ */
+export async function getForecast(
+  lat: number,
+  lon: number,
+  options: WeatherOptions = {},
+): Promise<WeatherResponse<ForecastData>> {
+  const { lang = 'ja', units = 'metric', skipCache = false } = options;
+
+  // 座標を小数点2桁に丸める
+  const roundedLat = Math.round(lat * 100) / 100;
+  const roundedLon = Math.round(lon * 100) / 100;
+
+  const cacheKey = generateCacheKey(`${CACHE_PREFIX.WEATHER}:forecast`, {
+    lat: roundedLat,
+    lon: roundedLon,
+    lang,
+    units,
+  });
+
+  const fetchForecast = async (): Promise<ForecastData> => {
+    return openWeatherMapClient.get<ForecastData>('/forecast', {
+      params: {
+        lat: String(lat),
+        lon: String(lon),
+        lang,
+        units,
+      },
+    });
+  };
+
+  if (skipCache) {
+    const data = await fetchForecast();
+    return {
+      data,
+      fromCache: false,
+      fetchedAt: new Date().toISOString(),
+    };
+  }
+
+  const { data, fromCache } = await withCache(cacheKey, CACHE_TTL.WEATHER, fetchForecast);
+
+  return {
+    data,
+    fromCache,
+    fetchedAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * APIキーが設定されているかチェック
+ */
+export function isWeatherApiConfigured(): boolean {
+  return Boolean(process.env.OPENWEATHERMAP_API_KEY);
+}


### PR DESCRIPTION
### 対応チケット
#37

### 実装
#### 1. APIエンドポイント (/api/weather)
機能:
`GET /api/weather?lat={緯度}&lon={経度}&type={current|forecast}&lang={言語}&units={単位系}`
```
  パラメータ:
  - lat (必須): 緯度 (-90 ~ 90)
  - lon (必須): 経度 (-180 ~ 180)
  - type (任意): current (現在の天気) または forecast (5日間予報)、デフォルト: current
  - lang (任意): 言語コード、デフォルト: ja
  - units (任意): standard, metric, imperial、デフォルト: metric
  - skipCache (任意): キャッシュをスキップするか、デフォルト: false
```
#### 2. キャッシング(Redis)
  - TTL: 30分
  - Upstash Redis REST API: サーバーレス対応
