### PR TITLE
場所検索用エンドポイント追加 #47

### DIFF
--- a/src/app/api/locations/search/route.ts
+++ b/src/app/api/locations/search/route.ts
@@ -1,0 +1,158 @@
+/**
+ * GET /api/locations/search
+ * 場所検索エンドポイント
+ *
+ * クエリパラメータ:
+ * - q: 検索クエリ（例: "東京", "築地市場"）
+ * - limit: 結果の上限数（デフォルト: 10）
+ * - skipCache: キャッシュをスキップするか（true|false）
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { searchLocations, isLocationSearchConfigured } from '@/lib/locationService';
+
+/**
+ * 検索クエリのバリデーション関数
+ */
+function isValidQuery(query: string): boolean {
+  // 制御文字をチェック
+  for (const char of query) {
+    const code = char.charCodeAt(0);
+    // 制御文字（0x00-0x1f, 0x7f）を除外
+    if ((code >= 0 && code <= 31) || code === 127) {
+      return false;
+    }
+  }
+  return true;
+}
+
+const LIMIT_REGEX = /^\d+$/;
+
+/**
+ * GET ハンドラ
+ */
+export async function GET(request: NextRequest) {
+  try {
+    // Google Maps API が設定されているか確認
+    if (!isLocationSearchConfigured()) {
+      return NextResponse.json(
+        {
+          error: 'Location search is not configured. Please set NEXT_PUBLIC_GOOGLE_MAPS_API_KEY.',
+          status: 503,
+        },
+        { status: 503 },
+      );
+    }
+
+    // クエリパラメータを抽出
+    const searchParams = request.nextUrl.searchParams;
+    const query = searchParams.get('q');
+    const limitParam = searchParams.get('limit') || '10';
+    const skipCache = searchParams.get('skipCache') === 'true';
+
+    // バリデーション: q パラメータが必須
+    if (!query) {
+      return NextResponse.json(
+        {
+          error: 'Missing required parameter: q',
+          status: 400,
+        },
+        { status: 400 },
+      );
+    }
+
+    // バリデーション: q の長さと内容
+    if (query.length < 2) {
+      return NextResponse.json(
+        {
+          error: 'Search query must be at least 2 characters',
+          status: 400,
+        },
+        { status: 400 },
+      );
+    }
+
+    if (query.length > 200) {
+      return NextResponse.json(
+        {
+          error: 'Search query must be less than 200 characters',
+          status: 400,
+        },
+        { status: 400 },
+      );
+    }
+
+    if (!isValidQuery(query)) {
+      return NextResponse.json(
+        {
+          error: 'Search query contains invalid characters',
+          status: 400,
+        },
+        { status: 400 },
+      );
+    }
+
+    // バリデーション: limit
+    if (!LIMIT_REGEX.test(limitParam)) {
+      return NextResponse.json(
+        {
+          error: 'Invalid limit parameter. Must be a positive number.',
+          status: 400,
+        },
+        { status: 400 },
+      );
+    }
+
+    const limit = Math.min(parseInt(limitParam, 10), 50); // 最大50件まで
+    if (limit < 1) {
+      return NextResponse.json(
+        {
+          error: 'Limit must be at least 1',
+          status: 400,
+        },
+        { status: 400 },
+      );
+    }
+
+    // 場所検索を実行
+    const response = await searchLocations(query, {
+      skipCache,
+      limit,
+    });
+
+    // レスポンスを返す
+    return NextResponse.json(
+      {
+        status: 200,
+        data: response.data,
+        meta: {
+          query: response.query,
+          count: response.data.length,
+          fromCache: response.fromCache,
+          fetchedAt: response.fetchedAt,
+        },
+      },
+      {
+        status: 200,
+        headers: {
+          'Cache-Control': response.fromCache
+            ? 'public, max-age=3600' // キャッシュから取得した場合は 1 時間キャッシュ
+            : 'public, max-age=300', // 新規取得の場合は 5 分キャッシュ
+        },
+      },
+    );
+  } catch (error) {
+    // エラーハンドリング
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+
+    console.error('[API] GET /api/locations/search error:', error);
+
+    return NextResponse.json(
+      {
+        error: errorMessage,
+        status: 500,
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -7,7 +7,7 @@
 export const CACHE_TTL = {
   WEATHER: 30 * 60, // 30分
   TIDE: 6 * 60 * 60, // 6時間
-  LOCATION: 24 * 60 * 60, // 24時間
+  LOCATION: 60 * 60, // 1時間
 } as const;
 
 // キャッシュキーのプレフィックス

--- a/src/lib/locationService.ts
+++ b/src/lib/locationService.ts
@@ -1,0 +1,132 @@
+/**
+ * 場所検索サービス
+ * Google Maps Geocoding API を使用して住所から座標を検索
+ */
+
+import { geocode } from './googleMapsClient';
+import { withCache, generateCacheKey, CACHE_PREFIX, CACHE_TTL } from './cache';
+import type { GeocodingResult } from '@/types/google.maps';
+import type {
+  LocationSearchResult,
+  LocationSearchOptions,
+  LocationSearchResponse,
+} from '@/types/location';
+
+/**
+ * Google Maps Geocoding API のレスポンスを
+ * アプリケーション用に整形
+ */
+function formatLocationResult(result: GeocodingResult): LocationSearchResult {
+  // 住所コンポーネントをパース
+  const addressComponents: Record<string, string> = {};
+  result.address_components.forEach((component) => {
+    if (component.types.includes('country')) {
+      addressComponents.country = component.short_name;
+    }
+    if (component.types.includes('administrative_area_level_1')) {
+      addressComponents.prefecture = component.long_name;
+    }
+    if (
+      component.types.includes('locality') ||
+      component.types.includes('administrative_area_level_2')
+    ) {
+      addressComponents.city = component.long_name;
+    }
+    if (component.types.includes('route') || component.types.includes('street_address')) {
+      addressComponents.street = component.long_name;
+    }
+  });
+
+  return {
+    place_id: result.place_id,
+    formatted_address: result.formatted_address,
+    latitude: result.geometry.location.lat,
+    longitude: result.geometry.location.lng,
+    address_components: addressComponents,
+    location_type: result.geometry.location_type,
+  };
+}
+
+/**
+ * 検索クエリから日本フィルタを含むクエリに変換
+ * @param query 元のクエリ
+ * @returns 日本限定のクエリ
+ */
+function buildJapanScopedQuery(query: string): string {
+  // 既に日本を含む場合はそのまま使用
+  if (query.toLowerCase().includes('japan') || query.includes('日本')) {
+    return query;
+  }
+  // 日本を明示的に付加
+  return `${query}, Japan`;
+}
+
+/**
+ * 場所を検索
+ * @param query 検索クエリ（地名、住所など）
+ * @param options 検索オプション
+ * @returns 検索結果
+ */
+export async function searchLocations(
+  query: string,
+  options: LocationSearchOptions = {},
+): Promise<LocationSearchResponse<LocationSearchResult>> {
+  const { skipCache = false, limit = 10 } = options;
+
+  // クエリのバリデーション
+  if (!query || query.trim().length < 2) {
+    throw new Error('Search query must be at least 2 characters');
+  }
+
+  if (query.length > 200) {
+    throw new Error('Search query must be less than 200 characters');
+  }
+
+  // 日本フィルタを適用
+  const scopedQuery = buildJapanScopedQuery(query.trim());
+
+  // キャッシュキーを生成
+  const cacheKey = generateCacheKey(CACHE_PREFIX.LOCATION, {
+    query: scopedQuery,
+    limit,
+  });
+
+  // 検索処理
+  const fetchLocations = async (): Promise<LocationSearchResult[]> => {
+    const response = await geocode(scopedQuery);
+
+    if (!response.results || response.results.length === 0) {
+      return [];
+    }
+
+    // 結果を整形して上限まで返す
+    return response.results.slice(0, limit).map(formatLocationResult);
+  };
+
+  // キャッシュを使用して検索実行
+  if (skipCache) {
+    const data = await fetchLocations();
+    return {
+      data,
+      fromCache: false,
+      fetchedAt: new Date().toISOString(),
+      query,
+    };
+  }
+
+  const { data, fromCache } = await withCache(cacheKey, CACHE_TTL.LOCATION, fetchLocations);
+
+  return {
+    data,
+    fromCache,
+    fetchedAt: new Date().toISOString(),
+    query,
+  };
+}
+
+/**
+ * Google Maps API が設定されているか確認
+ */
+export function isLocationSearchConfigured(): boolean {
+  return !!process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
+}

--- a/src/types/location.ts
+++ b/src/types/location.ts
@@ -1,0 +1,59 @@
+/**
+ * 場所検索関連の型定義
+ */
+
+/**
+ * 場所検索結果
+ */
+export interface LocationSearchResult {
+  /** Google Maps Place ID */
+  place_id: string;
+  /** フォーマット済みの住所 */
+  formatted_address: string;
+  /** 緯度 */
+  latitude: number;
+  /** 経度 */
+  longitude: number;
+  /** 住所の構成要素 */
+  address_components: LocationAddressComponents;
+  /** 座標の精度 */
+  location_type: 'ROOFTOP' | 'RANGE_INTERPOLATED' | 'GEOMETRIC_CENTER' | 'APPROXIMATE';
+}
+
+/**
+ * 住所の構成要素
+ */
+export interface LocationAddressComponents {
+  /** 国名 */
+  country?: string;
+  /** 都道府県名 */
+  prefecture?: string;
+  /** 市区町村名 */
+  city?: string;
+  /** 街区住居表示 */
+  street?: string;
+}
+
+/**
+ * 場所検索のオプション
+ */
+export interface LocationSearchOptions {
+  /** キャッシュをスキップするか */
+  skipCache?: boolean;
+  /** 取得する結果の上限数（デフォルト: 10） */
+  limit?: number;
+}
+
+/**
+ * 場所検索のレスポンス型
+ */
+export interface LocationSearchResponse<T> {
+  /** 検索結果の配列 */
+  data: T[];
+  /** キャッシュから取得したか */
+  fromCache: boolean;
+  /** データ取得時刻 */
+  fetchedAt: string;
+  /** 検索クエリ */
+  query: string;
+}


### PR DESCRIPTION
### 対応チケット
#47 

### 変更追加ファイル

  | ファイル                              | 内容                                                    |
  |---------------------------------------|---------------------------------------------------------|
  | src/types/location.ts                 | 場所検索関連の型定義（NEW）                             |
  | src/lib/locationService.ts            | Google Maps Geocoding API を利用した検索サービス（NEW） |
  | src/app/api/locations/search/route.ts | GET /api/locations/search エンドポイント（NEW）         |
  | src/lib/cache.ts                      | LOCATION キャッシュ TTL を 24h → 1h に修正              |

### 主要機能
#### LocationService 

  // 場所検索の実行
  const response = await searchLocations('東京', { limit: 10, skipCache: false });

  - Google Maps Geocoding API のラッパー
  - 検索結果の整形（place_id, formatted_address, lat/lng, address_components）
  - Redis キャッシング（TTL: 1時間）
  - 日本スコープの検索（"Japan" を自動付加）
  - クエリバリデーション（2〜200文字）

 #### API エンドポイント (GET /api/locations/search)

  # 基本的な使用法
  GET /api/locations/search?q=東京&limit=10

  # キャッシュをスキップ
  GET /api/locations/search?q=東京&skipCache=true

  リクエストパラメータ:
  - q (required): 検索クエリ（2〜200文字）
  - limit (optional): 結果上限数（デフォルト: 10、最大: 50）
  - skipCache (optional): キャッシュをスキップするか