### PR TITLE
釣りロジックに日の出日の入りなどを追加

### DIFF
--- a/docs/scoring-algorithm.md
+++ b/docs/scoring-algorithm.md
@@ -37,20 +37,23 @@ calculateTideScore(tide: TideData, currentTime: Date): number {
 ```typescript
 private calculateTideTimingScore(tide: TideData, currentTime: Date): number {
   const currentHour = currentTime.getHours();
+  const currentMinutes = currentTime.getMinutes();
+  const currentTotalMinutes = currentHour * 60 + currentMinutes;
   let maxScore = 0;
 
   // 満潮・干潮時刻の前後2時間を高評価
   for (const extreme of [...tide.highTides, ...tide.lowTides]) {
-    const extremeHour = new Date(extreme.time).getHours();
-    const timeDiff = Math.abs(currentHour - extremeHour);
+    const extremeTotalMinutes = /* 極値の時刻を分単位に変換 */;
+    const minDiff = Math.abs(extremeTotalMinutes - currentTotalMinutes);
+    const hoursFromExtreme = minDiff / 60;
 
-    if (timeDiff <= 2) {
+    if (hoursFromExtreme <= 2) {
       // 前後2時間以内: 高スコア
-      const score = 25 - (timeDiff * 5); // 2時間で25点から15点に減少
+      const score = 25 - hoursFromExtreme * 6.25; // 2時間で25点から12.5点に減少
       maxScore = Math.max(maxScore, score);
-    } else if (timeDiff <= 4) {
+    } else if (hoursFromExtreme <= 4) {
       // 前後4時間以内: 中スコア
-      const score = 15 - ((timeDiff - 2) * 5); // 4時間で15点から5点に減少
+      const score = 12.5 - (hoursFromExtreme - 2) * 6.25; // 4時間で12.5点から0点に減少
       maxScore = Math.max(maxScore, score);
     }
   }
@@ -153,44 +156,53 @@ private calculatePressureScore(pressure: number): number {
 
 ### 基本ロジック
 
-魚の活性が高い時間帯を評価します。一般的に早朝と夕方が最も釣りやすいとされています。
+日の出・日の入り前後の時間帯で魚の活性度を評価します。魚は光の変化に敏感で、日の出・日の入り前後が最も活発に活動します。
 
 ### 計算方法
 
 ```typescript
-calculateTimeScore(currentTime: Date): number {
-  const hour = currentTime.getHours();
+calculateTimeScore(weatherData: FormattedWeatherData, currentTime: Date): number {
+  const currentHour = currentTime.getHours();
+  const currentMinutes = currentTime.getMinutes();
+  const currentTotalMinutes = currentHour * 60 + currentMinutes;
 
-  // 時間帯別スコア
-  if (hour >= 5 && hour <= 7) return 25;    // 早朝 (5-7時): 最適
-  if (hour >= 17 && hour <= 19) return 25;  // 夕方 (17-19時): 最適
-  if (hour >= 4 && hour <= 8) return 20;    // 朝 (4-8時): 良好
-  if (hour >= 16 && hour <= 20) return 20;  // 夕 (16-20時): 良好
-  if (hour >= 9 && hour <= 15) return 10;   // 日中 (9-15時): 普通
-  if (hour >= 21 || hour <= 3) return 5;    // 夜間 (21-3時): やや不利
+  // 日の出・日の入り時刻を分単位で取得
+  const sunriseTotalMinutes = weatherData.sunrise.getHours() * 60 + weatherData.sunrise.getMinutes();
+  const sunsetTotalMinutes = weatherData.sunset.getHours() * 60 + weatherData.sunset.getMinutes();
 
-  return 10; // デフォルト
+  // 日の出・日の入りからの最短時間を計算（分単位）
+  const diffFromSunrise = Math.abs(currentTotalMinutes - sunriseTotalMinutes);
+  const diffFromSunset = Math.abs(currentTotalMinutes - sunsetTotalMinutes);
+  const minDiff = Math.min(diffFromSunrise, diffFromSunset);
+
+  // 時間を時間単位に変換
+  const hoursFromSunEvent = minDiff / 60;
+
+  // 日の出・日の入り前後でスコアを段階的に評価
+  if (hoursFromSunEvent <= 1) {
+    // ±1時間以内: 最高スコア
+    return 25;
+  } else if (hoursFromSunEvent <= 2) {
+    // ±2時間以内: 中スコア
+    return 15;
+  } else if (hoursFromSunEvent <= 3) {
+    // ±3時間以内: 低スコア
+    return 5;
+  }
+
+  // それ以外: スコアなし
+  return 0;
 }
 ```
 
-### 季節補正（将来実装予定）
+### 評価基準
 
-```typescript
-private applySeasonalAdjustment(score: number, month: number): number {
-  const seasonalMultipliers = {
-    spring: [3, 4, 5],     // 春: 1.1倍
-    summer: [6, 7, 8],     // 夏: 1.0倍
-    autumn: [9, 10, 11],   // 秋: 1.1倍
-    winter: [12, 1, 2]     // 冬: 0.9倍
-  };
-
-  // 季節による補正を適用
-  if (seasonalMultipliers.spring.includes(month)) return score * 1.1;
-  if (seasonalMultipliers.autumn.includes(month)) return score * 1.1;
-  if (seasonalMultipliers.winter.includes(month)) return score * 0.9;
-  return score; // 夏はそのまま
-}
-```
+| 時間帯 | スコア | 説明 |
+|--------|--------|------|
+| 日の出・日の入り ±1時間 | 25点 | 最適な釣り時間帯 |
+| 日の出・日の入り ±2時間 | 15点 | 良好な釣り時間帯 |
+| 日の出・日の入り ±3時間 | 5点 | やや期待できる時間帯 |
+| その他の時間帯 | 0点 | 通常の時間帯 |
 
 ---
 
@@ -211,15 +223,19 @@ export const ScoreInterpretation = {
 ### スコア内訳表示
 
 ```typescript
-interface ScoreBreakdown {
-  totalScore: number;
-  tideScore: number; // 潮汐スコア (最大40点)
-  weatherScore: number; // 天気スコア (最大35点)
-  timeScore: number; // 時間帯スコア (最大25点)
-  factors: {
-    tide: string[]; // 潮汐要因の詳細
-    weather: string[]; // 天気要因の詳細
-    time: string[]; // 時間帯要因の詳細
-  };
+interface ScoreComponents {
+  tide: number; // 潮汐スコア (最大40点)
+  weather: number; // 天気スコア (最大35点)
+  time: number; // 時間帯スコア (最大25点)
+}
+
+interface FishingScore {
+  score: number; // 総合スコア (0-100)
+  rank: ScoreRank;
+  components: ScoreComponents;
+  explanation: string;
+  bestComponent: 'tide' | 'weather' | 'time';
+  worstComponent: 'tide' | 'weather' | 'time';
+  calculatedAt: Date;
 }
 ```

--- a/src/lib/scoringService.ts
+++ b/src/lib/scoringService.ts
@@ -19,10 +19,10 @@ class ScoringEngine {
     // 各要素のスコアを計算
     const tideScore = this.calculateTideScore(tideData, currentTime);
     const weatherScore = this.calculateWeatherScore(weatherData);
+    const timeScore = this.calculateTimeScore(weatherData, currentTime);
 
-    // 総合スコア = 潮汐(65) + 天気(35)
-    // ※ 時間帯は潮汐タイミングスコアに完全に統合されているため、独立した評価は不要
-    const totalScore = tideScore + weatherScore;
+    // 総合スコア = 潮汐(40) + 天気(35) + 時間帯(25)
+    const totalScore = tideScore + weatherScore + timeScore;
 
     // スコアをクリップ (0-100)
     const clippedScore = Math.max(0, Math.min(100, Math.round(totalScore)));
@@ -34,15 +34,18 @@ class ScoringEngine {
     const components = {
       tide: tideScore,
       weather: weatherScore,
+      time: timeScore,
     };
 
     const bestComponent = Object.entries(components).reduce((a, b) => (b[1] > a[1] ? b : a))[0] as
       | 'tide'
-      | 'weather';
+      | 'weather'
+      | 'time';
 
     const worstComponent = Object.entries(components).reduce((a, b) => (b[1] < a[1] ? b : a))[0] as
       | 'tide'
-      | 'weather';
+      | 'weather'
+      | 'time';
 
     // 説明文を生成
     const explanation = this.generateExplanation(clippedScore, bestComponent, weatherData);
@@ -68,7 +71,7 @@ class ScoringEngine {
 
     if (!todayTides) {
       // データがない場合はニュートラルスコア
-      return 32.5; // 中間値
+      return 20; // 中間値（40点満点の半分）
     }
 
     const dailyTide = todayTides.daily;
@@ -102,7 +105,7 @@ class ScoringEngine {
 
     if (floods.length === 0 || edds.length === 0) {
       // 潮汐データが不完全な場合はニュートラルスコア
-      return 32.5; // 中間値
+      return 20; // 中間値（40点満点の半分）
     }
 
     // 現在時刻に最も近い極値までの時間を計算
@@ -112,7 +115,7 @@ class ScoringEngine {
       minDiff = Math.min(minDiff, diff);
     }
 
-    // 潮汐タイミングスコア (0-40点)
+    // 潮汐タイミングスコア (0-25点)
     // 満潮・干潮の前後2時間が釣りの最適時間帯
     let timingScore = 0;
     const minutesInHour = 60;
@@ -120,15 +123,15 @@ class ScoringEngine {
 
     if (hoursFromExtreme <= 2) {
       // 前後2時間以内: 高スコア
-      timingScore = 40 - hoursFromExtreme * 10; // 2時間で40点から20点に減少
+      timingScore = 25 - hoursFromExtreme * 6.25; // 2時間で25点から12.5点に減少
     } else if (hoursFromExtreme <= 4) {
       // 前後4時間以内: 中スコア
-      timingScore = 20 - (hoursFromExtreme - 2) * 10; // 4時間で20点から0点に減少
+      timingScore = 12.5 - (hoursFromExtreme - 2) * 6.25; // 4時間で12.5点から0点に減少
     } else {
       timingScore = 0;
     }
 
-    // 潮の大きさスコア (0-25点)
+    // 潮の大きさスコア (0-15点)
     // 現在時刻に最も近い満潮と干潮を見つける
     const nearestFlood = floods.reduce((closest, current) => {
       const currentDiff = Math.abs(current.totalMinutes - currentTotalMinutes);
@@ -147,14 +150,14 @@ class ScoringEngine {
 
     let sizeScore = 0;
     if (tideRange >= 1.5)
-      sizeScore = 25; // 大潮
+      sizeScore = 15; // 大潮
     else if (tideRange >= 1.0)
-      sizeScore = 20; // 中潮
+      sizeScore = 12; // 中潮
     else if (tideRange >= 0.5)
-      sizeScore = 13; // 小潮
-    else sizeScore = 8; // 長潮・若潮
+      sizeScore = 8; // 小潮
+    else sizeScore = 5; // 長潮・若潮
 
-    return Math.min(65, timingScore + sizeScore);
+    return Math.min(40, timingScore + sizeScore);
   }
 
   /**
@@ -209,11 +212,45 @@ class ScoringEngine {
 
   /**
    * 時間帯スコアを計算 (0-25点)
+   * 日の出・日の入り前後の時間帯で魚の活性度を評価
    */
-  // 【廃止】時間帯スコアは潮汐タイミングスコアに統合されました
-  // 理由：釣りで重要なのは、満潮・干潮の前後2時間という相対的なタイミング
-  // 時間帯（朝・昼・夜）は潮汐タイミングに比べて影響が小さいため、
-  // スコア配分を潮汐（65点）と天気（35点）に統合しました
+  private calculateTimeScore(weatherData: FormattedWeatherData, currentTime: Date): number {
+    const currentHour = currentTime.getHours();
+    const currentMinutes = currentTime.getMinutes();
+    const currentTotalMinutes = currentHour * 60 + currentMinutes;
+
+    // 日の出・日の入り時刻を分単位で取得
+    const sunriseHour = weatherData.sunrise.getHours();
+    const sunriseMinutes = weatherData.sunrise.getMinutes();
+    const sunriseTotalMinutes = sunriseHour * 60 + sunriseMinutes;
+
+    const sunsetHour = weatherData.sunset.getHours();
+    const sunsetMinutes = weatherData.sunset.getMinutes();
+    const sunsetTotalMinutes = sunsetHour * 60 + sunsetMinutes;
+
+    // 日の出・日の入りからの最短時間を計算（分単位）
+    const diffFromSunrise = Math.abs(currentTotalMinutes - sunriseTotalMinutes);
+    const diffFromSunset = Math.abs(currentTotalMinutes - sunsetTotalMinutes);
+    const minDiff = Math.min(diffFromSunrise, diffFromSunset);
+
+    // 時間を時間単位に変換
+    const hoursFromSunEvent = minDiff / 60;
+
+    // 日の出・日の入り前後でスコアを段階的に評価
+    if (hoursFromSunEvent <= 1) {
+      // ±1時間以内: 最高スコア
+      return 25;
+    } else if (hoursFromSunEvent <= 2) {
+      // ±2時間以内: 中スコア
+      return 15;
+    } else if (hoursFromSunEvent <= 3) {
+      // ±3時間以内: 低スコア
+      return 5;
+    }
+
+    // それ以外: スコアなし
+    return 0;
+  }
 
   /**
    * スコアからランクを判定

--- a/src/lib/scoringService.ts
+++ b/src/lib/scoringService.ts
@@ -48,7 +48,19 @@ class ScoringEngine {
       | 'time';
 
     // 説明文を生成
-    const explanation = this.generateExplanation(clippedScore, bestComponent, weatherData);
+    const explanation = this.generateExplanation(
+      clippedScore,
+      bestComponent,
+      weatherData,
+      tideData,
+      currentTime,
+    );
+
+    // 月齢と潮の種類を取得（tide736.net APIから）
+    const today = this.formatDateToString(currentTime);
+    const todayTides = tideData.tides.find((t) => t.date === today);
+    const tideName = todayTides?.daily.moon?.title;
+    const moonAge = todayTides?.daily.moon?.age;
 
     return {
       score: clippedScore,
@@ -57,6 +69,8 @@ class ScoringEngine {
       explanation,
       bestComponent,
       worstComponent,
+      tideName,
+      moonAge,
       calculatedAt: currentTime,
     };
   }
@@ -270,6 +284,8 @@ class ScoringEngine {
     score: number,
     bestComponent: 'tide' | 'weather' | 'time',
     weatherData: FormattedWeatherData,
+    tideData: FormattedTideData,
+    currentTime: Date,
   ): string {
     const rank = this.getRankFromScore(score);
 
@@ -296,6 +312,15 @@ class ScoringEngine {
     // 最良要素を追加
     const bestLabel = this.getComponentLabel(bestComponent);
     explanation += `\n最も良い条件は${bestLabel}です。`;
+
+    // 月齢と潮の種類を追加（tide736.net APIから取得）
+    const today = this.formatDateToString(currentTime);
+    const todayTides = tideData.tides.find((t) => t.date === today);
+    if (todayTides?.daily.moon) {
+      const moonAge = todayTides.daily.moon.age;
+      const tideName = todayTides.daily.moon.title; // APIから潮の種類を取得
+      explanation += `\n🌙 本日は${tideName}です（月齢：${moonAge.toFixed(1)}）。`;
+    }
 
     // 天気に関する追加情報
     if (weatherData.windSpeed > 10) {

--- a/src/types/scoring.ts
+++ b/src/types/scoring.ts
@@ -45,6 +45,10 @@ export interface FishingScore {
   bestComponent: 'tide' | 'weather' | 'time';
   /** 最も悪い要素 */
   worstComponent: 'tide' | 'weather' | 'time';
+  /** 潮の種類（大潮、中潮、小潮、長潮、若潮） */
+  tideName?: string;
+  /** 月齢 (0-29.5) */
+  moonAge?: number;
   /** スコア計算時刻 */
   calculatedAt: Date;
 }

--- a/src/types/scoring.ts
+++ b/src/types/scoring.ts
@@ -6,10 +6,12 @@
  * スコア要素の詳細情報
  */
 export interface ScoreComponents {
-  /** 潮汐スコア (0-65点) - 満潮・干潮の前後2時間のタイミング評価 */
+  /** 潮汐スコア (0-40点) - 満潮・干潮の前後2時間のタイミング評価 */
   tide: number;
   /** 天気スコア (0-35点) - 風速、気象条件、気圧の安定性評価 */
   weather: number;
+  /** 時間帯スコア (0-25点) - 日の出・日の入り前後の時間帯評価 */
+  time: number;
 }
 
 /**
@@ -40,9 +42,9 @@ export interface FishingScore {
   /** スコアに関する説明 */
   explanation: string;
   /** 最も良い要素 */
-  bestComponent: 'tide' | 'weather';
+  bestComponent: 'tide' | 'weather' | 'time';
   /** 最も悪い要素 */
-  worstComponent: 'tide' | 'weather';
+  worstComponent: 'tide' | 'weather' | 'time';
   /** スコア計算時刻 */
   calculatedAt: Date;
 }


### PR DESCRIPTION
### 対応チケット
#53 

### 対応
  1. 日の出・日の入り時刻に基づく時間帯スコア (コミット: 6eac15f)

  - 時間帯スコアの復活: 潮汐40% + 天気35% + 時間25%
  - 評価ロジック:
    - 日の出・日の入り ±1時間: 25点（最適）
    - 日の出・日の入り ±2時間: 15点（良好）
    - 日の出・日の入り ±3時間: 5点（やや期待）
  - データソース: OpenWeatherMap APIの既存データ（sunrise/sunset）を活用

  2. 潮の種類と月齢の表示 (コミット: 7e25424)

  - tide736.net APIの活用:
    - moon.age: 月齢（0-29.5）
    - moon.title: 潮の種類（大潮、中潮、小潮、長潮、若潮）
  - 型定義の拡張: FishingScoreにtideNameとmoonAgeを追加
