### PR TITLE
♻️ refactor: Phase1 残り リファクタリング（日付/スコアランク/座標/APIエラー統一）

### DIFF
--- a/src/app/api/conditions/tide/route.ts
+++ b/src/app/api/conditions/tide/route.ts
@@ -11,23 +11,9 @@
  */
 
 import { type NextRequest, NextResponse } from 'next/server';
+import { createErrorResponse } from '@/lib/apiResponseHandler';
 import { logger } from '@/lib/logger';
 import { getTideData } from '@/lib/tideService';
-
-/**
- * バリデーション用の正規表現
- */
-const PREFECTURE_CODE_REGEX = /^[0-9]{1,2}$/;
-const PORT_CODE_REGEX = /^[a-zA-Z0-9]+$/;
-const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
-
-/**
- * 今日の日付を YYYY-MM-DD 形式で取得
- */
-function getTodayDateString(): string {
-  const today = new Date();
-  return today.toISOString().split('T')[0];
-}
 
 /**
  * GET ハンドラ
@@ -38,69 +24,33 @@ export async function GET(request: NextRequest) {
     const searchParams = request.nextUrl.searchParams;
     const prefectureCode = searchParams.get('prefectureCode');
     const portCode = searchParams.get('portCode');
-    const date = searchParams.get('date') || getTodayDateString();
+    const date = searchParams.get('date') || new Date().toISOString().split('T')[0];
     const range = (searchParams.get('range') as 'day' | 'week' | 'month') || 'week';
     const skipCache = searchParams.get('skipCache') === 'true';
 
     // バリデーション
     if (!prefectureCode) {
-      return NextResponse.json(
-        {
-          error: 'Missing required parameter: prefectureCode',
-          status: 400,
-        },
-        { status: 400 },
-      );
+      return createErrorResponse('Missing required parameter: prefectureCode', 400);
     }
 
     if (!portCode) {
-      return NextResponse.json(
-        {
-          error: 'Missing required parameter: portCode',
-          status: 400,
-        },
-        { status: 400 },
-      );
+      return createErrorResponse('Missing required parameter: portCode', 400);
     }
 
-    if (!PREFECTURE_CODE_REGEX.test(prefectureCode)) {
-      return NextResponse.json(
-        {
-          error: 'Invalid prefectureCode format',
-          status: 400,
-        },
-        { status: 400 },
-      );
+    if (!/^[0-9]{1,2}$/.test(prefectureCode)) {
+      return createErrorResponse('Invalid prefectureCode format', 400);
     }
 
-    if (!PORT_CODE_REGEX.test(portCode)) {
-      return NextResponse.json(
-        {
-          error: 'Invalid portCode format',
-          status: 400,
-        },
-        { status: 400 },
-      );
+    if (!/^[a-zA-Z0-9]+$/.test(portCode)) {
+      return createErrorResponse('Invalid portCode format', 400);
     }
 
-    if (!DATE_REGEX.test(date)) {
-      return NextResponse.json(
-        {
-          error: 'Invalid date format. Use YYYY-MM-DD',
-          status: 400,
-        },
-        { status: 400 },
-      );
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+      return createErrorResponse('Invalid date format. Use YYYY-MM-DD', 400);
     }
 
     if (!['day', 'week', 'month'].includes(range)) {
-      return NextResponse.json(
-        {
-          error: 'Invalid range. Must be one of: day, week, month',
-          status: 400,
-        },
-        { status: 400 },
-      );
+      return createErrorResponse('Invalid range. Must be one of: day, week, month', 400);
     }
 
     // 潮汐データを取得

--- a/src/app/api/favorites/route.ts
+++ b/src/app/api/favorites/route.ts
@@ -10,20 +10,13 @@ import { auth } from '@/auth';
 import { Prisma } from '@/generated/prisma/client';
 import { logger } from '@/lib/logger';
 import prisma from '@/lib/prisma';
-import { isValidUUID } from '@/lib/validators';
+import { isValidUUID, roundCoordinate } from '@/lib/validators';
 import type {
   FavoriteAddResponse,
   FavoriteLocation,
   FavoriteRequest,
   FavoritesResponse,
 } from '@/types/favorites';
-
-/**
- * 座標を小数点4桁に丸める（約11m精度）
- */
-function roundCoordinate(coord: number): number {
-  return Math.round(coord * 10000) / 10000;
-}
 
 /**
  * お気に入り一覧取得

--- a/src/app/api/locations/search/route.ts
+++ b/src/app/api/locations/search/route.ts
@@ -9,6 +9,7 @@
  */
 
 import { type NextRequest, NextResponse } from 'next/server';
+import { createErrorResponse } from '@/lib/apiResponseHandler';
 import { isLocationSearchConfigured, searchLocations } from '@/lib/locationService';
 import { logger } from '@/lib/logger';
 
@@ -36,12 +37,9 @@ export async function GET(request: NextRequest) {
   try {
     // Google Maps API が設定されているか確認
     if (!isLocationSearchConfigured()) {
-      return NextResponse.json(
-        {
-          error: 'Location search is not configured. Please set NEXT_PUBLIC_GOOGLE_MAPS_API_KEY.',
-          status: 503,
-        },
-        { status: 503 },
+      return createErrorResponse(
+        'Location search is not configured. Please set NEXT_PUBLIC_GOOGLE_MAPS_API_KEY.',
+        503,
       );
     }
 
@@ -53,66 +51,30 @@ export async function GET(request: NextRequest) {
 
     // バリデーション: q パラメータが必須
     if (!query) {
-      return NextResponse.json(
-        {
-          error: 'Missing required parameter: q',
-          status: 400,
-        },
-        { status: 400 },
-      );
+      return createErrorResponse('Missing required parameter: q', 400);
     }
 
     // バリデーション: q の長さと内容
     if (query.length < 2) {
-      return NextResponse.json(
-        {
-          error: 'Search query must be at least 2 characters',
-          status: 400,
-        },
-        { status: 400 },
-      );
+      return createErrorResponse('Search query must be at least 2 characters', 400);
     }
 
     if (query.length > 200) {
-      return NextResponse.json(
-        {
-          error: 'Search query must be less than 200 characters',
-          status: 400,
-        },
-        { status: 400 },
-      );
+      return createErrorResponse('Search query must be less than 200 characters', 400);
     }
 
     if (!isValidQuery(query)) {
-      return NextResponse.json(
-        {
-          error: 'Search query contains invalid characters',
-          status: 400,
-        },
-        { status: 400 },
-      );
+      return createErrorResponse('Search query contains invalid characters', 400);
     }
 
     // バリデーション: limit
     if (!LIMIT_REGEX.test(limitParam)) {
-      return NextResponse.json(
-        {
-          error: 'Invalid limit parameter. Must be a positive number.',
-          status: 400,
-        },
-        { status: 400 },
-      );
+      return createErrorResponse('Invalid limit parameter. Must be a positive number.', 400);
     }
 
     const limit = Math.min(parseInt(limitParam, 10), 50); // 最大50件まで
     if (limit < 1) {
-      return NextResponse.json(
-        {
-          error: 'Limit must be at least 1',
-          status: 400,
-        },
-        { status: 400 },
-      );
+      return createErrorResponse('Limit must be at least 1', 400);
     }
 
     // 場所検索を実行

--- a/src/app/api/weather/route.ts
+++ b/src/app/api/weather/route.ts
@@ -5,8 +5,8 @@
 
 import { type NextRequest, NextResponse } from 'next/server';
 import { ApiError } from '@/lib/apiClient';
-import { createErrorResponse } from '@/lib/apiResponseHandler';
 import { logApiError } from '@/lib/apiErrorUtils';
+import { createErrorResponse } from '@/lib/apiResponseHandler';
 import { logger } from '@/lib/logger';
 import { getCurrentWeather, getForecast, isWeatherApiConfigured } from '@/lib/openWeatherService';
 import { parseAndValidateCoordinates } from '@/lib/validators';
@@ -47,7 +47,11 @@ export async function GET(request: NextRequest) {
 
   // typeパラメータのバリデーション
   if (type !== 'current' && type !== 'forecast') {
-    return createErrorResponse('typeは "current" または "forecast" である必要があります', 400, 'INVALID_PARAMS');
+    return createErrorResponse(
+      'typeは "current" または "forecast" である必要があります',
+      400,
+      'INVALID_PARAMS',
+    );
   }
 
   // unitsパラメータのバリデーション

--- a/src/app/api/weather/route.ts
+++ b/src/app/api/weather/route.ts
@@ -8,35 +8,7 @@ import { ApiError } from '@/lib/apiClient';
 import { logApiError } from '@/lib/apiErrorUtils';
 import { logger } from '@/lib/logger';
 import { getCurrentWeather, getForecast, isWeatherApiConfigured } from '@/lib/openWeatherService';
-
-/**
- * 座標パラメータのバリデーション
- */
-function validateCoordinates(
-  lat: string | null,
-  lon: string | null,
-): { lat: number; lon: number } | { error: string } {
-  if (!lat || !lon) {
-    return { error: '緯度(lat)と経度(lon)は必須パラメータです' };
-  }
-
-  const latNum = parseFloat(lat);
-  const lonNum = parseFloat(lon);
-
-  if (Number.isNaN(latNum) || Number.isNaN(lonNum)) {
-    return { error: '緯度と経度は有効な数値である必要があります' };
-  }
-
-  if (latNum < -90 || latNum > 90) {
-    return { error: '緯度は-90から90の範囲である必要があります' };
-  }
-
-  if (lonNum < -180 || lonNum > 180) {
-    return { error: '経度は-180から180の範囲である必要があります' };
-  }
-
-  return { lat: latNum, lon: lonNum };
-}
+import { parseAndValidateCoordinates } from '@/lib/validators';
 
 /**
  * GET /api/weather
@@ -61,7 +33,7 @@ export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
 
   // 座標パラメータの取得とバリデーション
-  const coordResult = validateCoordinates(searchParams.get('lat'), searchParams.get('lon'));
+  const coordResult = parseAndValidateCoordinates(searchParams.get('lat'), searchParams.get('lon'));
 
   if ('error' in coordResult) {
     return NextResponse.json({ error: coordResult.error, code: 'INVALID_PARAMS' }, { status: 400 });

--- a/src/app/api/weather/route.ts
+++ b/src/app/api/weather/route.ts
@@ -5,6 +5,7 @@
 
 import { type NextRequest, NextResponse } from 'next/server';
 import { ApiError } from '@/lib/apiClient';
+import { createErrorResponse } from '@/lib/apiResponseHandler';
 import { logApiError } from '@/lib/apiErrorUtils';
 import { logger } from '@/lib/logger';
 import { getCurrentWeather, getForecast, isWeatherApiConfigured } from '@/lib/openWeatherService';
@@ -24,10 +25,7 @@ export async function GET(request: NextRequest) {
   // APIキーのチェック
   if (!isWeatherApiConfigured()) {
     logger.error('OPENWEATHERMAP_API_KEY is not configured');
-    return NextResponse.json(
-      { error: 'Weather API is not configured', code: 'API_NOT_CONFIGURED' },
-      { status: 503 },
-    );
+    return createErrorResponse('Weather API is not configured', 503, 'API_NOT_CONFIGURED');
   }
 
   const searchParams = request.nextUrl.searchParams;
@@ -36,7 +34,7 @@ export async function GET(request: NextRequest) {
   const coordResult = parseAndValidateCoordinates(searchParams.get('lat'), searchParams.get('lon'));
 
   if ('error' in coordResult) {
-    return NextResponse.json({ error: coordResult.error, code: 'INVALID_PARAMS' }, { status: 400 });
+    return createErrorResponse(coordResult.error, 400, 'INVALID_PARAMS');
   }
 
   const { lat, lon } = coordResult;
@@ -49,20 +47,15 @@ export async function GET(request: NextRequest) {
 
   // typeパラメータのバリデーション
   if (type !== 'current' && type !== 'forecast') {
-    return NextResponse.json(
-      { error: 'typeは "current" または "forecast" である必要があります', code: 'INVALID_PARAMS' },
-      { status: 400 },
-    );
+    return createErrorResponse('typeは "current" または "forecast" である必要があります', 400, 'INVALID_PARAMS');
   }
 
   // unitsパラメータのバリデーション
   if (!['standard', 'metric', 'imperial'].includes(units)) {
-    return NextResponse.json(
-      {
-        error: 'unitsは "standard", "metric", または "imperial" である必要があります',
-        code: 'INVALID_PARAMS',
-      },
-      { status: 400 },
+    return createErrorResponse(
+      'unitsは "standard", "metric", または "imperial" である必要があります',
+      400,
+      'INVALID_PARAMS',
     );
   }
 

--- a/src/lib/apiResponseHandler.ts
+++ b/src/lib/apiResponseHandler.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+
+export function createErrorResponse(
+  message: string,
+  status: number,
+  code?: string,
+): NextResponse {
+  return NextResponse.json({ error: message, code, status }, { status });
+}

--- a/src/lib/apiResponseHandler.ts
+++ b/src/lib/apiResponseHandler.ts
@@ -1,9 +1,5 @@
 import { NextResponse } from 'next/server';
 
-export function createErrorResponse(
-  message: string,
-  status: number,
-  code?: string,
-): NextResponse {
+export function createErrorResponse(message: string, status: number, code?: string): NextResponse {
   return NextResponse.json({ error: message, code, status }, { status });
 }

--- a/src/lib/scoringService.ts
+++ b/src/lib/scoringService.ts
@@ -334,7 +334,6 @@ class ScoringEngine {
         return '時間帯';
     }
   }
-
 }
 
 // シングルトンインスタンスをエクスポート

--- a/src/lib/scoringService.ts
+++ b/src/lib/scoringService.ts
@@ -3,9 +3,11 @@
  * 潮汐、天気、時間帯から総合スコアを計算
  */
 
-import type { FishingScore, ScoreRank } from '@/types/scoring';
+import type { FishingScore } from '@/types/scoring';
 import type { FormattedWeatherData } from './openWeatherService';
 import type { FormattedTideData } from './tideService';
+import { formatDateLocal } from './utils/dateUtils';
+import { getScoreRank } from './utils/scoreRank';
 
 class ScoringEngine {
   /**
@@ -28,7 +30,7 @@ class ScoringEngine {
     const clippedScore = Math.max(0, Math.min(100, Math.round(totalScore)));
 
     // ランクを判定
-    const rank = this.getRankFromScore(clippedScore);
+    const rank = getScoreRank(clippedScore);
 
     // 最良・最悪要素を判定
     const components = {
@@ -57,7 +59,7 @@ class ScoringEngine {
     );
 
     // 月齢と潮の種類を取得（tide736.net APIから）
-    const today = this.formatDateToString(currentTime);
+    const today = formatDateLocal(currentTime);
     const todayTides = tideData.tides.find((t) => t.date === today);
     const tideName = todayTides?.daily.moon?.title;
     const moonAge = todayTides?.daily.moon?.age;
@@ -80,7 +82,7 @@ class ScoringEngine {
    */
   private calculateTideScore(tideData: FormattedTideData, currentTime: Date): number {
     // 本日の潮汐データを取得
-    const today = this.formatDateToString(currentTime);
+    const today = formatDateLocal(currentTime);
     const todayTides = tideData.tides.find((t) => t.date === today);
 
     if (!todayTides) {
@@ -267,17 +269,6 @@ class ScoringEngine {
   }
 
   /**
-   * スコアからランクを判定
-   */
-  private getRankFromScore(score: number): ScoreRank {
-    if (score >= 80) return 'excellent';
-    if (score >= 60) return 'good';
-    if (score >= 40) return 'fair';
-    if (score >= 20) return 'poor';
-    return 'bad';
-  }
-
-  /**
    * スコアに基づいて説明文を生成
    */
   private generateExplanation(
@@ -287,7 +278,7 @@ class ScoringEngine {
     tideData: FormattedTideData,
     currentTime: Date,
   ): string {
-    const rank = this.getRankFromScore(score);
+    const rank = getScoreRank(score);
 
     let explanation = '';
 
@@ -314,7 +305,7 @@ class ScoringEngine {
     explanation += `\n最も良い条件は${bestLabel}です。`;
 
     // 月齢と潮の種類を追加（tide736.net APIから取得）
-    const today = this.formatDateToString(currentTime);
+    const today = formatDateLocal(currentTime);
     const todayTides = tideData.tides.find((t) => t.date === today);
     if (todayTides?.daily.moon) {
       const moonAge = todayTides.daily.moon.age;
@@ -344,15 +335,6 @@ class ScoringEngine {
     }
   }
 
-  /**
-   * Dateオブジェクトを YYYY-MM-DD 形式の文字列に変換
-   */
-  private formatDateToString(date: Date): string {
-    const year = date.getFullYear();
-    const month = String(date.getMonth() + 1).padStart(2, '0');
-    const day = String(date.getDate()).padStart(2, '0');
-    return `${year}-${month}-${day}`;
-  }
 }
 
 // シングルトンインスタンスをエクスポート

--- a/src/lib/utils/dashboardUtils.ts
+++ b/src/lib/utils/dashboardUtils.ts
@@ -4,16 +4,7 @@
 
 import type { ScoreRank } from '@/types/scoring';
 
-/**
- * スコアからランクを取得
- */
-export function getScoreRank(score: number): ScoreRank {
-  if (score >= 80) return 'excellent';
-  if (score >= 60) return 'good';
-  if (score >= 40) return 'fair';
-  if (score >= 20) return 'poor';
-  return 'bad';
-}
+export { getScoreRank } from './scoreRank';
 
 /**
  * ランクから色を取得
@@ -50,12 +41,7 @@ export function formatTime(date: Date): string {
   return date.toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit' });
 }
 
-/**
- * 日付をフォーマット
- */
-export function formatDate(date: Date): string {
-  return date.toLocaleDateString('ja-JP', { month: 'long', day: 'numeric' });
-}
+export { formatDisplayDate as formatDate } from './dateUtils';
 
 /**
  * 風向を日本語に変換

--- a/src/lib/utils/dateUtils.ts
+++ b/src/lib/utils/dateUtils.ts
@@ -1,0 +1,14 @@
+// YYYY-MM-DD形式（ローカルタイムベース）
+// toISOString() は UTC ベースで日本（UTC+9）では午前0〜9時に前日の日付を返すため、
+// 潮汐データの日付マッチングにはローカルタイムが必要。
+export function formatDateLocal(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+// 日本語ロケール表示形式（dashboardUtils の formatDate 相当）
+export function formatDisplayDate(date: Date): string {
+  return date.toLocaleDateString('ja-JP', { month: 'long', day: 'numeric' });
+}

--- a/src/lib/utils/scoreRank.ts
+++ b/src/lib/utils/scoreRank.ts
@@ -1,0 +1,9 @@
+import type { ScoreRank } from '@/types/scoring';
+
+export function getScoreRank(score: number): ScoreRank {
+  if (score >= 80) return 'excellent';
+  if (score >= 60) return 'good';
+  if (score >= 40) return 'fair';
+  if (score >= 20) return 'poor';
+  return 'bad';
+}

--- a/src/lib/validators/coordinateValidator.ts
+++ b/src/lib/validators/coordinateValidator.ts
@@ -1,0 +1,26 @@
+// 座標の丸め処理（小数点4桁 = 約11m精度）
+export function roundCoordinate(value: number, precision = 4): number {
+  return Math.round(value * 10 ** precision) / 10 ** precision;
+}
+
+// 文字列クエリパラメータをパース + バリデーション
+export function parseAndValidateCoordinates(
+  lat: string | null,
+  lon: string | null,
+): { lat: number; lon: number } | { error: string } {
+  if (!lat || !lon) {
+    return { error: '緯度(lat)と経度(lon)は必須パラメータです' };
+  }
+  const latNum = parseFloat(lat);
+  const lonNum = parseFloat(lon);
+  if (Number.isNaN(latNum) || Number.isNaN(lonNum)) {
+    return { error: '緯度と経度は有効な数値である必要があります' };
+  }
+  if (latNum < -90 || latNum > 90) {
+    return { error: '緯度は-90から90の範囲である必要があります' };
+  }
+  if (lonNum < -180 || lonNum > 180) {
+    return { error: '経度は-180から180の範囲である必要があります' };
+  }
+  return { lat: latNum, lon: lonNum };
+}

--- a/src/lib/validators/index.ts
+++ b/src/lib/validators/index.ts
@@ -1,1 +1,2 @@
 export { isValidUUID, UUID_REGEX } from './uuidValidator';
+export { roundCoordinate, parseAndValidateCoordinates } from './coordinateValidator';

--- a/src/lib/validators/index.ts
+++ b/src/lib/validators/index.ts
@@ -1,2 +1,2 @@
+export { parseAndValidateCoordinates, roundCoordinate } from './coordinateValidator';
 export { isValidUUID, UUID_REGEX } from './uuidValidator';
-export { roundCoordinate, parseAndValidateCoordinates } from './coordinateValidator';


### PR DESCRIPTION
## 概要

Phase 1 リファクタリングの未完了3項目（PR-2〜PR-4）をまとめて対応した。インライン重複実装を専用モジュールに切り出し、振る舞いは変えずにコードの重複を解消する。

## 変更内容

- `src/lib/utils/dateUtils.ts` 新規作成 — `formatDateLocal`（ローカルタイムYYYY-MM-DD）、`formatDisplayDate`（日本語表示）
- `src/lib/utils/scoreRank.ts` 新規作成 — `getScoreRank`（スコア→ScoreRank判定）
- `src/lib/validators/coordinateValidator.ts` 新規作成 — `roundCoordinate`、`parseAndValidateCoordinates`
- `src/lib/apiResponseHandler.ts` 新規作成 — `createErrorResponse`（エラーレスポンス統一）
- `src/lib/scoringService.ts` — private `getRankFromScore`/`formatDateToString` を削除し外部インポートに移行
- `src/lib/utils/dashboardUtils.ts` — `getScoreRank`/`formatDate` を re-export に変更
- `src/lib/validators/index.ts` — coordinateValidator を追加
- `src/app/api/favorites/route.ts` — インライン `roundCoordinate` を削除しインポートに変更
- `src/app/api/weather/route.ts` — インライン `validateCoordinates` を削除、バリデーションエラーを統一
- `src/app/api/conditions/tide/route.ts` — インライン定数・関数を削除、バリデーションエラーを統一
- `src/app/api/locations/search/route.ts` — バリデーションエラーを統一

## テスト計画

- [x] 型チェック: `npm run type-check`
- [x] Lint: `npm run lint`
- [ ] ビルド: `npm run build`（ローカル環境変数要確認）
- [ ] 手動動作確認（天気・潮汐・場所検索・お気に入りAPI）