### PR TITLE
refactor: useFavorites.ts を fetch/optimistic/requestBuilder に分解 #11

### DIFF
--- a/src/hooks/useFavorites.ts
+++ b/src/hooks/useFavorites.ts
@@ -1,8 +1,10 @@
+// src/hooks/useFavorites.ts
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
-import { logger } from '@/lib/logger';
-import type { FavoriteAddResponse, FavoriteLocation, FavoritesResponse } from '@/types/favorites';
+import { useCallback } from 'react';
+import type { FavoriteLocation } from '@/types/favorites';
+import { useFavoritesFetch } from './useFavoritesFetch';
+import { useFavoritesOptimistic } from './useFavoritesOptimistic';
 
 interface UseFavoritesReturn {
   favorites: FavoriteLocation[];
@@ -22,174 +24,21 @@ interface UseFavoritesReturn {
 }
 
 export function useFavorites(): UseFavoritesReturn {
-  const [favorites, setFavorites] = useState<FavoriteLocation[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const { favorites, setFavorites, isLoading, error, fetchFavorites } = useFavoritesFetch();
+  const { addFavorite, removeFavorite } = useFavoritesOptimistic({
+    favorites,
+    setFavorites,
+    fetchFavorites,
+  });
 
-  // お気に入り一覧を取得
-  const fetchFavorites = useCallback(async () => {
-    setIsLoading(true);
-    setError(null);
-
-    try {
-      const response = await fetch('/api/favorites');
-
-      if (!response.ok) {
-        if (response.status === 401) {
-          throw new Error('ログインが必要です');
-        }
-        throw new Error('お気に入りの取得に失敗しました');
-      }
-
-      const data: FavoritesResponse = await response.json();
-      setFavorites(data.favorites);
-    } catch (err) {
-      logger.error({ err }, 'Failed to fetch favorites');
-      setError(err instanceof Error ? err.message : 'エラーが発生しました');
-      setFavorites([]);
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
-
-  // 初回マウント時に取得
-  useEffect(() => {
-    fetchFavorites();
-  }, [fetchFavorites]);
-
-  // お気に入りに追加
-  const addFavorite = useCallback(
-    async (
-      locationId?: string,
-      portId?: string,
-      lat?: number,
-      lng?: number,
-      name?: string,
-    ): Promise<string> => {
-      // 楽観的UI更新（仮のお気に入りを追加）
-      const tempFavorite: FavoriteLocation = {
-        id: 'temp',
-        locationId: locationId || 'temp',
-        name: name || '',
-        latitude: lat || 0,
-        longitude: lng || 0,
-        createdAt: new Date().toISOString(),
-      };
-
-      setFavorites((prev) => [tempFavorite, ...prev]);
-
-      try {
-        // リクエストボディを構築
-        const requestBody: {
-          locationId?: string;
-          portId?: string;
-          coordinates?: { lat: number; lng: number; name: string };
-        } = {};
-
-        if (locationId) {
-          requestBody.locationId = locationId;
-        } else if (portId) {
-          requestBody.portId = portId;
-        } else if (lat !== undefined && lng !== undefined && name) {
-          requestBody.coordinates = { lat, lng, name };
-        }
-
-        const response = await fetch('/api/favorites', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify(requestBody),
-        });
-
-        if (!response.ok) {
-          const errorData = await response.json();
-
-          if (response.status === 409) {
-            throw new Error('既にお気に入りに追加されています');
-          } else if (response.status === 404) {
-            throw new Error('釣り場が見つかりません');
-          } else if (response.status === 401) {
-            throw new Error('ログインが必要です');
-          }
-
-          throw new Error(errorData.error || 'お気に入りの追加に失敗しました');
-        }
-
-        // APIから登録されたlocationIdを取得
-        const data: FavoriteAddResponse = await response.json();
-
-        // 成功したら最新のデータを取得
-        await fetchFavorites();
-
-        return data.locationId;
-      } catch (err) {
-        logger.error({ err, locationId, portId, lat, lng }, 'Failed to add favorite');
-
-        // エラーが発生したら楽観的更新を元に戻す
-        setFavorites((prev) => prev.filter((fav) => fav.id !== 'temp'));
-
-        throw err;
-      }
-    },
-    [fetchFavorites],
-  );
-
-  // お気に入りから削除
-  const removeFavorite = useCallback(
-    async (locationId: string) => {
-      // 楽観的UI更新（削除対象を除外）
-      const previousFavorites = favorites;
-      setFavorites((prev) => prev.filter((fav) => fav.locationId !== locationId));
-
-      try {
-        const response = await fetch(`/api/favorites?locationId=${locationId}`, {
-          method: 'DELETE',
-        });
-
-        if (!response.ok) {
-          const errorData = await response.json();
-
-          if (response.status === 404) {
-            throw new Error('お気に入りが見つかりません');
-          } else if (response.status === 401) {
-            throw new Error('ログインが必要です');
-          }
-
-          throw new Error(errorData.error || 'お気に入りの削除に失敗しました');
-        }
-      } catch (err) {
-        logger.error({ err, locationId }, 'Failed to remove favorite');
-
-        // エラーが発生したら楽観的更新を元に戻す
-        setFavorites(previousFavorites);
-
-        throw err;
-      }
-    },
-    [favorites],
-  );
-
-  // 指定されたlocationIdがお気に入りに含まれているか
   const isFavorite = useCallback(
-    (locationId: string) => {
-      return favorites.some((fav) => fav.locationId === locationId);
-    },
+    (locationId: string) => favorites.some((fav) => fav.locationId === locationId),
     [favorites],
   );
 
-  // 手動でリフレッシュ
   const refetch = useCallback(() => {
     fetchFavorites();
   }, [fetchFavorites]);
 
-  return {
-    favorites,
-    isLoading,
-    error,
-    addFavorite,
-    removeFavorite,
-    isFavorite,
-    refetch,
-  };
+  return { favorites, isLoading, error, addFavorite, removeFavorite, isFavorite, refetch };
 }

--- a/src/hooks/useFavoritesFetch.ts
+++ b/src/hooks/useFavoritesFetch.ts
@@ -1,0 +1,43 @@
+// src/hooks/useFavoritesFetch.ts
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { logger } from '@/lib/logger';
+import type { FavoriteLocation, FavoritesResponse } from '@/types/favorites';
+
+export function useFavoritesFetch() {
+  const [favorites, setFavorites] = useState<FavoriteLocation[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchFavorites = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch('/api/favorites');
+
+      if (!response.ok) {
+        if (response.status === 401) {
+          throw new Error('ログインが必要です');
+        }
+        throw new Error('お気に入りの取得に失敗しました');
+      }
+
+      const data: FavoritesResponse = await response.json();
+      setFavorites(data.favorites);
+    } catch (err) {
+      logger.error({ err }, 'Failed to fetch favorites');
+      setError(err instanceof Error ? err.message : 'エラーが発生しました');
+      setFavorites([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchFavorites();
+  }, [fetchFavorites]);
+
+  return { favorites, setFavorites, isLoading, error, fetchFavorites };
+}

--- a/src/hooks/useFavoritesOptimistic.ts
+++ b/src/hooks/useFavoritesOptimistic.ts
@@ -1,0 +1,106 @@
+// src/hooks/useFavoritesOptimistic.ts
+'use client';
+
+import type { Dispatch, SetStateAction } from 'react';
+import { useCallback } from 'react';
+import { logger } from '@/lib/logger';
+import type { FavoriteAddResponse, FavoriteLocation } from '@/types/favorites';
+import { buildFavoriteRequestBody } from './utils/favoriteRequestBuilder';
+
+interface UseFavoritesOptimisticProps {
+  favorites: FavoriteLocation[];
+  setFavorites: Dispatch<SetStateAction<FavoriteLocation[]>>;
+  fetchFavorites: () => Promise<void>;
+}
+
+export function useFavoritesOptimistic({
+  favorites,
+  setFavorites,
+  fetchFavorites,
+}: UseFavoritesOptimisticProps) {
+  const addFavorite = useCallback(
+    async (
+      locationId?: string,
+      portId?: string,
+      lat?: number,
+      lng?: number,
+      name?: string,
+    ): Promise<string> => {
+      const tempFavorite: FavoriteLocation = {
+        id: 'temp',
+        locationId: locationId || 'temp',
+        name: name || '',
+        latitude: lat || 0,
+        longitude: lng || 0,
+        createdAt: new Date().toISOString(),
+      };
+
+      setFavorites((prev) => [tempFavorite, ...prev]);
+
+      try {
+        const requestBody = buildFavoriteRequestBody(locationId, portId, lat, lng, name);
+
+        const response = await fetch('/api/favorites', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(requestBody),
+        });
+
+        if (!response.ok) {
+          const errorData = await response.json();
+
+          if (response.status === 409) {
+            throw new Error('既にお気に入りに追加されています');
+          } else if (response.status === 404) {
+            throw new Error('釣り場が見つかりません');
+          } else if (response.status === 401) {
+            throw new Error('ログインが必要です');
+          }
+
+          throw new Error(errorData.error || 'お気に入りの追加に失敗しました');
+        }
+
+        const data: FavoriteAddResponse = await response.json();
+        await fetchFavorites();
+        return data.locationId;
+      } catch (err) {
+        logger.error({ err, locationId, portId, lat, lng }, 'Failed to add favorite');
+        setFavorites((prev) => prev.filter((fav) => fav.id !== 'temp'));
+        throw err;
+      }
+    },
+    [setFavorites, fetchFavorites],
+  );
+
+  const removeFavorite = useCallback(
+    async (locationId: string) => {
+      const previousFavorites = favorites;
+      setFavorites((prev) => prev.filter((fav) => fav.locationId !== locationId));
+
+      try {
+        const response = await fetch(`/api/favorites?locationId=${locationId}`, {
+          method: 'DELETE',
+        });
+
+        if (!response.ok) {
+          const errorData = await response.json();
+
+          if (response.status === 404) {
+            throw new Error('お気に入りが見つかりません');
+          } else if (response.status === 401) {
+            throw new Error('ログインが必要です');
+          }
+
+          throw new Error(errorData.error || 'お気に入りの削除に失敗しました');
+        }
+      } catch (err) {
+        logger.error({ err, locationId }, 'Failed to remove favorite');
+        setFavorites(previousFavorites);
+        throw err;
+      }
+    },
+    [favorites, setFavorites],
+  );
+
+  return { addFavorite, removeFavorite };
+}

--- a/src/hooks/utils/favoriteRequestBuilder.ts
+++ b/src/hooks/utils/favoriteRequestBuilder.ts
@@ -1,0 +1,21 @@
+// src/hooks/utils/favoriteRequestBuilder.ts
+import type { FavoriteRequest } from '@/types/favorites';
+
+export function buildFavoriteRequestBody(
+  locationId?: string,
+  portId?: string,
+  lat?: number,
+  lng?: number,
+  name?: string,
+): FavoriteRequest {
+  if (locationId) {
+    return { locationId };
+  }
+  if (portId) {
+    return { portId };
+  }
+  if (lat !== undefined && lng !== undefined && name) {
+    return { coordinates: { lat, lng, name } };
+  }
+  return {};
+}


### PR DESCRIPTION
## Summary

- `src/hooks/useFavorites.ts`（195行）を3つのサブフックに分解
  - `src/hooks/utils/favoriteRequestBuilder.ts` — リクエストボディ構築の純粋関数
  - `src/hooks/useFavoritesFetch.ts` — お気に入り一覧の取得と状態管理
  - `src/hooks/useFavoritesOptimistic.ts` — 楽観的UI更新（追加・削除）
- `useFavorites.ts` は3つのサブフックを合成するだけの約40行に縮小
- 公開 API（`UseFavoritesReturn` 型）の変更なし

## Test plan

- [x] `npx tsc --noEmit` エラーなし
- [x] `npm run format:check` 通過
- [x] `useFavorites()` の戻り値インターフェースが変わらないことを確認（既存呼び出し元への影響なし）
- [x] 楽観的更新・ロールバック・fetchFavorites 再取得のロジックが保持されていることを確認