### PR TITLE
refactor: DashboardGrid からお気に入りロジックを useDashboardFavorite に抽出 #14

### DIFF
--- a/src/components/organisms/DashboardGrid.tsx
+++ b/src/components/organisms/DashboardGrid.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { motion } from 'framer-motion';
-import { useRouter } from 'next/navigation';
 import { FavoriteButton } from '@/components/atoms/FavoriteButton';
 import { FishingLocationMap } from '@/components/molecules/FishingLocationMap';
 import { ScoreCard } from '@/components/molecules/ScoreCard';
@@ -17,7 +16,7 @@ import {
   mapAnimation,
 } from '@/constants/animations';
 import { DASHBOARD_LABELS } from '@/constants/labels';
-import { useFavorites } from '@/hooks/useFavorites';
+import { useDashboardFavorite } from '@/hooks/useDashboardFavorite';
 import type { DashboardData } from '@/types/dashboard';
 
 interface DashboardGridProps {
@@ -38,40 +37,7 @@ interface DashboardGridProps {
 }
 
 export function DashboardGrid({ data, location }: DashboardGridProps) {
-  const router = useRouter();
-  const { isFavorite, addFavorite, removeFavorite, isLoading } = useFavorites();
-
-  const handleToggleFavorite = async () => {
-    try {
-      const locationId = location.id || '';
-      if (isFavorite(locationId)) {
-        await removeFavorite(locationId);
-      } else {
-        // locationIdがある場合はそれを使用、ない場合はsourceから作成
-        let newLocationId: string;
-        if (location.id) {
-          newLocationId = await addFavorite(location.id);
-        } else if (location.source?.type === 'port' && location.source.portId) {
-          newLocationId = await addFavorite(undefined, location.source.portId);
-        } else if (location.source?.type === 'coordinates' && location.source.coordinates) {
-          newLocationId = await addFavorite(
-            undefined,
-            undefined,
-            location.source.coordinates.lat,
-            location.source.coordinates.lng,
-            location.source.coordinates.name,
-          );
-        } else {
-          return;
-        }
-
-        // 新しいlocationIdでURLを更新（portIdや座標ではなくlocationIdで管理）
-        router.replace(`/dashboard?locationId=${newLocationId}`);
-      }
-    } catch {
-      // エラーはuseFavorites内でログ出力済み
-    }
-  };
+  const { isFavorite, isLoading, handleToggleFavorite } = useDashboardFavorite(location);
 
   return (
     <div className="container mx-auto px-4 py-8 max-w-7xl">
@@ -86,7 +52,7 @@ export function DashboardGrid({ data, location }: DashboardGridProps) {
             {data.location.name} {DASHBOARD_LABELS.LOCATION_SUFFIX}
           </h1>
           <FavoriteButton
-            isFavorite={isFavorite(location.id || '')}
+            isFavorite={isFavorite}
             isLoading={isLoading}
             onToggle={handleToggleFavorite}
             size="lg"

--- a/src/hooks/useDashboardFavorite.ts
+++ b/src/hooks/useDashboardFavorite.ts
@@ -24,7 +24,8 @@ export function useDashboardFavorite(location: DashboardLocation) {
 
   const handleToggleFavorite = useCallback(async () => {
     try {
-      if (isFavorite) {
+      const currentIsFavorite = checkIsFavorite(locationId);
+      if (currentIsFavorite) {
         await removeFavorite(locationId);
         return;
       }
@@ -51,7 +52,7 @@ export function useDashboardFavorite(location: DashboardLocation) {
     } catch {
       // エラーはuseFavorites内でログ出力済み
     }
-  }, [isFavorite, locationId, location, addFavorite, removeFavorite, router]);
+  }, [locationId, location, addFavorite, removeFavorite, router, checkIsFavorite]);
 
   return { isFavorite, isLoading, handleToggleFavorite };
 }

--- a/src/hooks/useDashboardFavorite.ts
+++ b/src/hooks/useDashboardFavorite.ts
@@ -1,0 +1,57 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useCallback } from 'react';
+import { useFavorites } from './useFavorites';
+
+interface LocationSource {
+  type: 'port' | 'coordinates';
+  portId?: string;
+  coordinates?: { lat: number; lng: number; name: string };
+}
+
+interface DashboardLocation {
+  id?: string;
+  source?: LocationSource;
+}
+
+export function useDashboardFavorite(location: DashboardLocation) {
+  const router = useRouter();
+  const { isFavorite: checkIsFavorite, addFavorite, removeFavorite, isLoading } = useFavorites();
+
+  const locationId = location.id || '';
+  const isFavorite = checkIsFavorite(locationId);
+
+  const handleToggleFavorite = useCallback(async () => {
+    try {
+      if (isFavorite) {
+        await removeFavorite(locationId);
+        return;
+      }
+
+      let newLocationId: string;
+
+      if (location.id) {
+        newLocationId = await addFavorite(location.id);
+      } else if (location.source?.type === 'port' && location.source.portId) {
+        newLocationId = await addFavorite(undefined, location.source.portId);
+      } else if (location.source?.type === 'coordinates' && location.source.coordinates) {
+        newLocationId = await addFavorite(
+          undefined,
+          undefined,
+          location.source.coordinates.lat,
+          location.source.coordinates.lng,
+          location.source.coordinates.name,
+        );
+      } else {
+        return;
+      }
+
+      router.replace(`/dashboard?locationId=${newLocationId}`);
+    } catch {
+      // エラーはuseFavorites内でログ出力済み
+    }
+  }, [isFavorite, locationId, location, addFavorite, removeFavorite, router]);
+
+  return { isFavorite, isLoading, handleToggleFavorite };
+}


### PR DESCRIPTION
## Summary

- `DashboardGrid.tsx` からお気に入りトグル処理とルーティングロジックを `useDashboardFavorite` フックに抽出
  - `src/hooks/useDashboardFavorite.ts` を新規作成
  - `DashboardGrid.tsx` はレイアウト・レンダリングのみに専念
- バグ修正も含む: `handleToggleFavorite` の `useCallback` 依存配列から boolean の `isFavorite` を除去し、コールバック内では `checkIsFavorite(locationId)` を呼び出すよう修正（ステールクロージャ対策）

## Test plan

- [x] `npx tsc --noEmit` エラーなし
- [x] `npm run format:check` 通過
- [x] お気に入り追加・削除・URL更新ロジックが保持されていることを確認
- [x] `useCallback` 依存配列が正しく `[locationId, location, addFavorite, removeFavorite, router, checkIsFavorite]` になっていることを確認