### PR TITLE
refactor: LocationSearchTabs から usePortsData / useLocationSearch を抽出 #13

### DIFF
--- a/src/components/organisms/LocationSearchTabs/FreeSearchTab.tsx
+++ b/src/components/organisms/LocationSearchTabs/FreeSearchTab.tsx
@@ -1,20 +1,14 @@
+// src/components/organisms/LocationSearchTabs/FreeSearchTab.tsx
 'use client';
 
 import { Loader2, MapPin, Search } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { Input } from '@/components/ui/input';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import { logger } from '@/lib/logger';
+import type { SearchResult } from '@/hooks/useLocationSearch';
+import { useLocationSearch } from '@/hooks/useLocationSearch';
 import { cn } from '@/lib/utils';
-
-interface SearchResult {
-  place_id: string;
-  formatted_address: string;
-  name: string;
-  latitude: number;
-  longitude: number;
-}
 
 interface FreeSearchTabProps {
   onLocationSelect?: (location: { lat: number; lng: number; name: string }) => void;
@@ -23,54 +17,7 @@ interface FreeSearchTabProps {
 export function FreeSearchTab({ onLocationSelect }: FreeSearchTabProps) {
   const router = useRouter();
   const [query, setQuery] = useState('');
-  const [results, setResults] = useState<SearchResult[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [debouncedQuery, setDebouncedQuery] = useState('');
-
-  // debounce処理（300ms）
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setDebouncedQuery(query);
-    }, 300);
-
-    return () => clearTimeout(timer);
-  }, [query]);
-
-  // 検索実行
-  useEffect(() => {
-    const searchLocations = async () => {
-      if (debouncedQuery.length < 2) {
-        setResults([]);
-        setError(null);
-        return;
-      }
-
-      setIsLoading(true);
-      setError(null);
-
-      try {
-        const response = await fetch(
-          `/api/locations/search?q=${encodeURIComponent(debouncedQuery)}`,
-        );
-
-        if (!response.ok) {
-          throw new Error('検索に失敗しました');
-        }
-
-        const data = await response.json();
-        setResults(data.data || []);
-      } catch (err) {
-        logger.error({ err }, 'Location search error');
-        setError(err instanceof Error ? err.message : '検索中にエラーが発生しました');
-        setResults([]);
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    searchLocations();
-  }, [debouncedQuery]);
+  const { results, isLoading, error } = useLocationSearch(query);
 
   const handleSelectLocation = useCallback(
     (result: SearchResult) => {
@@ -80,7 +27,6 @@ export function FreeSearchTab({ onLocationSelect }: FreeSearchTabProps) {
         name: result.name || result.formatted_address,
       };
 
-      // URLパラメータで直接 dashboard に遷移
       const params = new URLSearchParams({
         lat: location.lat.toString(),
         lng: location.lng.toString(),
@@ -98,7 +44,6 @@ export function FreeSearchTab({ onLocationSelect }: FreeSearchTabProps) {
 
   return (
     <div className="space-y-3">
-      {/* 検索バー */}
       <div className="relative">
         <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
         <Input
@@ -113,14 +58,12 @@ export function FreeSearchTab({ onLocationSelect }: FreeSearchTabProps) {
         )}
       </div>
 
-      {/* エラーメッセージ */}
       {error && (
         <div className="rounded-lg bg-destructive/10 p-2 text-xs text-destructive wrap-break-word">
           {error}
         </div>
       )}
 
-      {/* 検索結果 */}
       {results.length > 0 && (
         <ScrollArea className="h-[200px] rounded-lg border">
           <div className="p-1 space-y-1">
@@ -150,7 +93,6 @@ export function FreeSearchTab({ onLocationSelect }: FreeSearchTabProps) {
         </ScrollArea>
       )}
 
-      {/* 空状態 */}
       {!isLoading && query.length >= 2 && results.length === 0 && !error && (
         <div className="text-center py-4 text-xs text-muted-foreground">
           検索結果が見つかりませんでした

--- a/src/components/organisms/LocationSearchTabs/PortSelectionTab.tsx
+++ b/src/components/organisms/LocationSearchTabs/PortSelectionTab.tsx
@@ -1,8 +1,9 @@
+// src/components/organisms/LocationSearchTabs/PortSelectionTab.tsx
 'use client';
 
 import { Anchor, Loader2 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import {
   Select,
@@ -11,22 +12,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import type { Port } from '@/hooks/usePortsData';
+import { usePortsData } from '@/hooks/usePortsData';
 import { logger } from '@/lib/logger';
-
-interface Port {
-  id: string;
-  name: string;
-  prefecture_code: string;
-  prefecture_name: string | null;
-  port_code: string;
-  latitude: number | null;
-  longitude: number | null;
-}
-
-interface Prefecture {
-  code: string;
-  name: string;
-}
 
 interface PortSelectionTabProps {
   onPortSelect?: (port: Port) => void;
@@ -34,55 +22,10 @@ interface PortSelectionTabProps {
 
 export function PortSelectionTab({ onPortSelect }: PortSelectionTabProps) {
   const router = useRouter();
+  const { allPorts, prefectures, isLoading, error } = usePortsData();
   const [selectedPrefecture, setSelectedPrefecture] = useState<string>('');
   const [selectedPortId, setSelectedPortId] = useState<string>('');
-  const [allPorts, setAllPorts] = useState<Port[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
 
-  // 初回マウント時に全港を取得
-  useEffect(() => {
-    const fetchAllPorts = async () => {
-      setIsLoading(true);
-      setError(null);
-
-      try {
-        const response = await fetch('/api/ports');
-
-        if (!response.ok) {
-          throw new Error('港情報の取得に失敗しました');
-        }
-
-        const data = await response.json();
-        setAllPorts(data.ports || []);
-      } catch (err) {
-        logger.error({ err }, 'Failed to fetch all ports');
-        setError(err instanceof Error ? err.message : 'エラーが発生しました');
-        setAllPorts([]);
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    fetchAllPorts();
-  }, []);
-
-  // 都道府県一覧を生成（港データから重複なしで抽出）
-  const prefectures = useMemo<Prefecture[]>(() => {
-    const prefMap = new Map<string, string>();
-
-    allPorts.forEach((port) => {
-      if (!prefMap.has(port.prefecture_code) && port.prefecture_name) {
-        prefMap.set(port.prefecture_code, port.prefecture_name);
-      }
-    });
-
-    return Array.from(prefMap.entries())
-      .map(([code, name]) => ({ code, name }))
-      .sort((a, b) => parseInt(a.code, 10) - parseInt(b.code, 10));
-  }, [allPorts]);
-
-  // 選択された都道府県の港一覧をフィルタリング
   const filteredPorts = useMemo(() => {
     if (!selectedPrefecture) {
       return [];
@@ -104,7 +47,6 @@ export function PortSelectionTab({ onPortSelect }: PortSelectionTabProps) {
         return;
       }
 
-      // portId で直接 dashboard に遷移
       router.push(`/dashboard?portId=${port.id}`);
 
       if (onPortSelect) {
@@ -116,7 +58,6 @@ export function PortSelectionTab({ onPortSelect }: PortSelectionTabProps) {
 
   return (
     <div className="space-y-3">
-      {/* 都道府県選択 */}
       <Select value={selectedPrefecture} onValueChange={setSelectedPrefecture}>
         <SelectTrigger disabled={isLoading || allPorts.length === 0}>
           <SelectValue placeholder="都道府県を選択" />
@@ -132,19 +73,16 @@ export function PortSelectionTab({ onPortSelect }: PortSelectionTabProps) {
         </SelectContent>
       </Select>
 
-      {/* ローディング */}
       {isLoading && (
         <div className="flex items-center justify-center py-8">
           <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
         </div>
       )}
 
-      {/* エラーメッセージ */}
       {error && (
         <div className="rounded-lg bg-destructive/10 p-3 text-sm text-destructive">{error}</div>
       )}
 
-      {/* 港選択 */}
       {!isLoading && filteredPorts.length > 0 && (
         <Select value={selectedPortId} onValueChange={handlePortChange}>
           <SelectTrigger>
@@ -175,7 +113,6 @@ export function PortSelectionTab({ onPortSelect }: PortSelectionTabProps) {
         </Select>
       )}
 
-      {/* 空状態 */}
       {!isLoading && selectedPrefecture && filteredPorts.length === 0 && !error && (
         <div className="text-center py-8 text-sm text-muted-foreground">
           この都道府県に登録されている港がありません

--- a/src/hooks/useLocationSearch.ts
+++ b/src/hooks/useLocationSearch.ts
@@ -1,0 +1,66 @@
+// src/hooks/useLocationSearch.ts
+'use client';
+
+import { useEffect, useState } from 'react';
+import { logger } from '@/lib/logger';
+
+export interface SearchResult {
+  place_id: string;
+  formatted_address: string;
+  name: string;
+  latitude: number;
+  longitude: number;
+}
+
+export function useLocationSearch(query: string) {
+  const [results, setResults] = useState<SearchResult[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [debouncedQuery, setDebouncedQuery] = useState('');
+
+  // debounce処理（300ms）
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedQuery(query);
+    }, 300);
+
+    return () => clearTimeout(timer);
+  }, [query]);
+
+  // 検索実行
+  useEffect(() => {
+    const searchLocations = async () => {
+      if (debouncedQuery.length < 2) {
+        setResults([]);
+        setError(null);
+        return;
+      }
+
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const response = await fetch(
+          `/api/locations/search?q=${encodeURIComponent(debouncedQuery)}`,
+        );
+
+        if (!response.ok) {
+          throw new Error('検索に失敗しました');
+        }
+
+        const data = await response.json();
+        setResults(data.data || []);
+      } catch (err) {
+        logger.error({ err }, 'Location search error');
+        setError(err instanceof Error ? err.message : '検索中にエラーが発生しました');
+        setResults([]);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    searchLocations();
+  }, [debouncedQuery]);
+
+  return { results, isLoading, error };
+}

--- a/src/hooks/usePortsData.ts
+++ b/src/hooks/usePortsData.ts
@@ -1,0 +1,68 @@
+// src/hooks/usePortsData.ts
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { logger } from '@/lib/logger';
+
+export interface Port {
+  id: string;
+  name: string;
+  prefecture_code: string;
+  prefecture_name: string | null;
+  port_code: string;
+  latitude: number | null;
+  longitude: number | null;
+}
+
+export interface Prefecture {
+  code: string;
+  name: string;
+}
+
+export function usePortsData() {
+  const [allPorts, setAllPorts] = useState<Port[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchAllPorts = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch('/api/ports');
+
+      if (!response.ok) {
+        throw new Error('港情報の取得に失敗しました');
+      }
+
+      const data = await response.json();
+      setAllPorts(data.ports || []);
+    } catch (err) {
+      logger.error({ err }, 'Failed to fetch all ports');
+      setError(err instanceof Error ? err.message : 'エラーが発生しました');
+      setAllPorts([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchAllPorts();
+  }, [fetchAllPorts]);
+
+  const prefectures = useMemo<Prefecture[]>(() => {
+    const prefMap = new Map<string, string>();
+
+    allPorts.forEach((port) => {
+      if (!prefMap.has(port.prefecture_code) && port.prefecture_name) {
+        prefMap.set(port.prefecture_code, port.prefecture_name);
+      }
+    });
+
+    return Array.from(prefMap.entries())
+      .map(([code, name]) => ({ code, name }))
+      .sort((a, b) => parseInt(a.code, 10) - parseInt(b.code, 10));
+  }, [allPorts]);
+
+  return { allPorts, prefectures, isLoading, error };
+}


### PR DESCRIPTION
## Summary

- `PortSelectionTab.tsx` と `FreeSearchTab.tsx` からデータ取得ロジックをカスタムフックに分離
  - `src/hooks/usePortsData.ts` — 港一覧の取得・都道府県リスト生成（`Port`・`Prefecture` 型もエクスポート）
  - `src/hooks/useLocationSearch.ts` — 場所検索（300ms debounce・`SearchResult` 型もエクスポート）
- 各コンポーネントはレンダリングのみに専念、公開インターフェース変更なし

## Test plan

- [x] `npx tsc --noEmit` エラーなし
- [x] `npm run format:check` 通過
- [x] `PortSelectionTab` のUI・動作（都道府県→港選択→dashboard遷移）が変わらないことを確認
- [x] `FreeSearchTab` の debounce 300ms・API 呼び出し・結果表示が変わらないことを確認